### PR TITLE
Fix `UpdateMember` encoding & decoding

### DIFF
--- a/src/Connector.sol
+++ b/src/Connector.sol
@@ -141,7 +141,7 @@ contract CentrifugeConnector {
         uint64 poolId,
         bytes16 trancheId,
         address user,
-        uint256 validUntil
+        uint64 validUntil
     ) public onlyRouter {
         Tranche storage tranche = tranches[poolId][trancheId];
         require(tranche.latestPrice > 0, "CentrifugeConnector/invalid-pool-or-tranche");

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -117,16 +117,41 @@ library ConnectorMessages {
         validUntil = uint256(_msg.index(45, 32));
     }
 
-    function parseUpdateMemberDebug(bytes29 _msg) internal pure returns (uint64 poolId, bytes16 trancheId) {
+    function parseUpdateMemberDebug(bytes29 _msg) internal pure returns (uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) {
         poolId = uint64(_msg.indexUint(1, 8));
         trancheId = bytes16(_msg.index(9, 16));
-//        user = address(bytes20(_msg.index(25, 20)));
-//        // TODO: skip 12 padded zeroes from address
-//        validUntil = uint256(_msg.index(45, 32));
+        user = address(bytes20(_msg.index(25, 20)));
+        validUntil = uint64(_msg.indexUint(57, 8));
     }
 
-    function parseTrancheId(bytes29 _msg) internal pure returns (bytes16 trancheId) {
-        trancheId = bytes16(_msg.index(0, 16));
+    // Convert an hexadecimal character to their value
+    function fromHexChar(uint8 c) internal pure returns (uint8) {
+        if (bytes1(c) >= bytes1("0") && bytes1(c) <= bytes1("9")) {
+            return c - uint8(bytes1("0"));
+        }
+        if (bytes1(c) >= bytes1("a") && bytes1(c) <= bytes1("f")) {
+            return 10 + c - uint8(bytes1("a"));
+        }
+        if (bytes1(c) >= bytes1("A") && bytes1(c) <= bytes1("F")) {
+            return 10 + c - uint8(bytes1("A"));
+        }
+        revert("Failed to encode hex char");
+    }
+
+    // Convert an hexadecimal string to raw bytes
+    function fromHex(string memory s) internal pure returns (bytes memory) {
+        bytes memory ss = bytes(s);
+        require(ss.length % 2 == 0); // length must be even
+        bytes memory r = new bytes(ss.length / 2);
+
+        for (uint256 i = 0; i < ss.length / 2; ++i) {
+            r[i] = bytes1(
+                fromHexChar(uint8(ss[2 * i])) *
+                16 +
+                fromHexChar(uint8(ss[2 * i + 1]))
+            );
+        }
+        return r;
     }
 
     /**

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -96,12 +96,12 @@ library ConnectorMessages {
      * 0: call type (uint8 = 1 byte)
      * 1-8: poolId (uint64 = 8 bytes)
      * 9-25: trancheId (16 bytes)
-     * 26-46: user (Ethereum address, 20 bytes)
-     * 47-78: validUntil (uint256 = 32 bytes)
+     * 25-45: user (Ethereum address, 20 bytes - Skip 12 bytes from 32-byte addresses)
+     * 57-65: validUntil (uint64 = 8 bytes)
      * 
      * TODO: use bytes32 for user (for non-EVM compatibility)
      */
-    function formatUpdateMember(uint64 poolId, bytes16 trancheId, address user, uint256 validUntil) internal pure returns (bytes memory) {
+    function formatUpdateMember(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) internal pure returns (bytes memory) {
         return abi.encodePacked(uint8(Call.UpdateMember), poolId, trancheId, user, validUntil);
     }
 
@@ -109,15 +109,8 @@ library ConnectorMessages {
         return messageType(_msg) == Call.UpdateMember;
     }
 
-    function parseUpdateMember(bytes29 _msg) internal pure returns (uint64 poolId, bytes16 trancheId, address user, uint256 validUntil) {
-        poolId = uint64(_msg.indexUint(1, 8));
-        trancheId = bytes16(_msg.index(9, 16));
-        user = address(bytes20(_msg.index(25, 20)));
-        // TODO: skip 12 padded zeroes from address
-        validUntil = uint256(_msg.index(45, 32));
-    }
 
-    function parseUpdateMemberDebug(bytes29 _msg) internal pure returns (uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) {
+    function parseUpdateMember(bytes29 _msg) internal pure returns (uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) {
         poolId = uint64(_msg.indexUint(1, 8));
         trancheId = bytes16(_msg.index(9, 16));
         user = address(bytes20(_msg.index(25, 20)));

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -102,7 +102,7 @@ library ConnectorMessages {
      * TODO: use bytes32 for user (for non-EVM compatibility)
      */
     function formatUpdateMember(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) internal pure returns (bytes memory) {
-        return abi.encodePacked(uint8(Call.UpdateMember), poolId, trancheId, user, validUntil);
+        return abi.encodePacked(uint8(Call.UpdateMember), poolId, trancheId, user, bytes(hex"000000000000000000000000"), validUntil);
     }
 
     function isUpdateMember(bytes29 _msg) internal pure returns (bool) {

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -50,7 +50,7 @@ library ConnectorMessages {
     function formatAddTranche(uint64 poolId, bytes16 trancheId, string memory tokenName, string memory tokenSymbol) internal pure returns (bytes memory) {
         // TODO(nuno): Now, we encode `tokenName` as a 128-bytearray by first encoding `tokenName`
         // to bytes32 and then we encode three empty bytes32's, which sum up to a total of 128 bytes.
-        // Add support to actually encode `tokennName` fully as a 128 bytes string.
+        // Add support to actually encode `tokenName` fully as a 128 bytes string.
         return abi.encodePacked(uint8(Call.AddTranche), poolId, trancheId, stringToBytes32(tokenName), bytes32(""), bytes32(""), bytes32(""), stringToBytes32(tokenSymbol));
     }
 
@@ -115,6 +115,18 @@ library ConnectorMessages {
         user = address(bytes20(_msg.index(25, 20)));
         // TODO: skip 12 padded zeroes from address
         validUntil = uint256(_msg.index(45, 32));
+    }
+
+    function parseUpdateMemberDebug(bytes29 _msg) internal pure returns (uint64 poolId, bytes16 trancheId) {
+        poolId = uint64(_msg.indexUint(1, 8));
+        trancheId = bytes16(_msg.index(9, 16));
+//        user = address(bytes20(_msg.index(25, 20)));
+//        // TODO: skip 12 padded zeroes from address
+//        validUntil = uint256(_msg.index(45, 32));
+    }
+
+    function parseTrancheId(bytes29 _msg) internal pure returns (bytes16 trancheId) {
+        trancheId = bytes16(_msg.index(0, 16));
     }
 
     /**

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -117,36 +117,6 @@ library ConnectorMessages {
         validUntil = uint64(_msg.indexUint(57, 8));
     }
 
-    // Convert an hexadecimal character to their value
-    function fromHexChar(uint8 c) internal pure returns (uint8) {
-        if (bytes1(c) >= bytes1("0") && bytes1(c) <= bytes1("9")) {
-            return c - uint8(bytes1("0"));
-        }
-        if (bytes1(c) >= bytes1("a") && bytes1(c) <= bytes1("f")) {
-            return 10 + c - uint8(bytes1("a"));
-        }
-        if (bytes1(c) >= bytes1("A") && bytes1(c) <= bytes1("F")) {
-            return 10 + c - uint8(bytes1("A"));
-        }
-        revert("Failed to encode hex char");
-    }
-
-    // Convert an hexadecimal string to raw bytes
-    function fromHex(string memory s) internal pure returns (bytes memory) {
-        bytes memory ss = bytes(s);
-        require(ss.length % 2 == 0); // length must be even
-        bytes memory r = new bytes(ss.length / 2);
-
-        for (uint256 i = 0; i < ss.length / 2; ++i) {
-            r[i] = bytes1(
-                fromHexChar(uint8(ss[2 * i])) *
-                16 +
-                fromHexChar(uint8(ss[2 * i + 1]))
-            );
-        }
-        return r;
-    }
-
     /**
      * Update token price
      * 

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -102,6 +102,8 @@ library ConnectorMessages {
      * TODO: use bytes32 for user (for non-EVM compatibility)
      */
     function formatUpdateMember(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) internal pure returns (bytes memory) {
+        // NOTE: Since parseUpdateMember parses the first 20 bytes of `user` and skips the following 12
+        // here we need to append 12 zeros to make it right. Drop once we support 32-byte addresses.
         return abi.encodePacked(uint8(Call.UpdateMember), poolId, trancheId, user, bytes(hex"000000000000000000000000"), validUntil);
     }
 

--- a/src/routers/xcm/Router.sol
+++ b/src/routers/xcm/Router.sol
@@ -8,7 +8,7 @@ import {ConnectorMessages} from "../../Messages.sol";
 interface ConnectorLike {
   function addPool(uint64 poolId) external;
   function addTranche(uint64 poolId, bytes16 trancheId, string memory tokenName, string memory tokenSymbol) external;
-  function updateMember(uint64 poolId, bytes16 trancheId, address user, uint256 validUntil) external;
+  function updateMember(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) external;
   function updateTokenPrice(uint64 poolId, bytes16 trancheId, uint256 price) external;
   function handleTransfer(uint64 poolId, bytes16 trancheId, address user, uint256 amount) external;
 }
@@ -50,7 +50,7 @@ contract ConnectorXCMRouter {
             (uint64 poolId, bytes16 trancheId, string memory tokenName, string memory tokenSymbol) = ConnectorMessages.parseAddTranche(_msg);
             connector.addTranche(poolId, trancheId, tokenName, tokenSymbol);
         } else if (ConnectorMessages.isUpdateMember(_msg) == true) {
-            (uint64 poolId, bytes16 trancheId, address user, uint256 validUntil) = ConnectorMessages.parseUpdateMember(_msg);
+            (uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) = ConnectorMessages.parseUpdateMember(_msg);
             connector.updateMember(poolId, trancheId, user, validUntil);
         } else if (ConnectorMessages.isUpdateTokenPrice(_msg) == true) {
             (uint64 poolId, bytes16 trancheId, uint256 price) = ConnectorMessages.parseUpdateTokenPrice(_msg);

--- a/src/routers/xcm/Router.sol
+++ b/src/routers/xcm/Router.sol
@@ -67,7 +67,7 @@ contract ConnectorXCMRouter {
         // TODO: implement
     }
 
-    function bytes32ToString(bytes32 _bytes32) internal returns (string memory) {
+    function bytes32ToString(bytes32 _bytes32) internal pure returns (string memory) {
         uint8 i = 0;
         while (i < 32 && _bytes32[i] != 0) {
             i++;

--- a/test/Connector.t.sol
+++ b/test/Connector.t.sol
@@ -92,9 +92,8 @@ contract ConnectorTest is Test {
         homeConnector.addTranche(poolId, trancheId, tokenName, tokenSymbol);
     }
 
-    function testUpdatingMemberWorks(uint64 poolId, bytes16 trancheId, address user, uint128 fuzzed_uint128) public {
-        vm.assume(fuzzed_uint128 > 0);
-        uint256 validUntil = safeAdd(fuzzed_uint128, safeAdd(block.timestamp, minimumDelay));
+    function testUpdatingMemberWorks(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) public {
+        vm.assume(validUntil <= safeAdd(block.timestamp, new Memberlist().minimumDelay()));
         vm.assume(user != address(0));
 
         homeConnector.addPool(poolId);
@@ -110,7 +109,7 @@ contract ConnectorTest is Test {
         assertEq(memberlist.members(user), validUntil);
     }
 
-    function testUpdatingMemberBeforeMinimumDelayFails(uint64 poolId, bytes16 trancheId, address user, uint256 validUntil) public {
+    function testUpdatingMemberBeforeMinimumDelayFails(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) public {
         vm.assume(validUntil <= safeAdd(block.timestamp, new Memberlist().minimumDelay()));
         vm.assume(user != address(0));
 
@@ -121,16 +120,15 @@ contract ConnectorTest is Test {
         homeConnector.updateMember(poolId, trancheId, user, validUntil);
     }
 
-    function testUpdatingMemberAsNonRouterFails(uint64 poolId, bytes16 trancheId, address user, uint128 fuzzed_uint128) public {
-        vm.assume(fuzzed_uint128 > 0);
-        uint256 validUntil = safeAdd(fuzzed_uint128, safeAdd(block.timestamp, new Memberlist().minimumDelay()));
+    function testUpdatingMemberAsNonRouterFails(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) public {
+        vm.assume(validUntil <= safeAdd(block.timestamp, new Memberlist().minimumDelay()));
         vm.assume(user != address(0));
 
         vm.expectRevert(bytes("CentrifugeConnector/not-the-router"));
         bridgedConnector.updateMember(poolId, trancheId, user, validUntil);
     }
 
-    function testUpdatingMemberForNonExistentPoolFails(uint64 poolId, bytes16 trancheId, address user, uint256 validUntil) public {
+    function testUpdatingMemberForNonExistentPoolFails(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) public {
         vm.assume(validUntil > block.timestamp);
         bridgedConnector.file("router", address(this));
         vm.expectRevert(bytes("CentrifugeConnector/invalid-pool-or-tranche"));
@@ -138,7 +136,7 @@ contract ConnectorTest is Test {
     }
 
 
-    function testUpdatingMemberForNonExistentTrancheFails(uint64 poolId, bytes16 trancheId, address user, uint256 validUntil) public {
+    function testUpdatingMemberForNonExistentTrancheFails(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) public {
         vm.assume(validUntil > block.timestamp);
         bridgedConnector.file("router", address(this));
         bridgedConnector.addPool(poolId);

--- a/test/Connector.t.sol
+++ b/test/Connector.t.sol
@@ -93,7 +93,7 @@ contract ConnectorTest is Test {
     }
 
     function testUpdatingMemberWorks(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) public {
-        vm.assume(validUntil <= safeAdd(block.timestamp, new Memberlist().minimumDelay()));
+        vm.assume(validUntil >= safeAdd(block.timestamp, new Memberlist().minimumDelay()));
         vm.assume(user != address(0));
 
         homeConnector.addPool(poolId);

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -89,7 +89,14 @@ contract MessagesTest is Test {
         assertEq(decodedTokenSymbol, bytes32ToString(stringToBytes32(tokenSymbol)));
     }
 
-    function testUpdateMemberDecodingThatFailed() public {
+    function testUpdateMemberEncoding() public {
+        assertEq(
+            ConnectorMessages.formatUpdateMember(2, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"), 0x1231231231231231231231231231231231231231, 1706260138),
+            hex"040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312310000000000000000000000000000000065b376aa"
+        );
+    }
+
+    function testUpdateMemberDecoding() public {
         (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint64 decodedValidUntil) = ConnectorMessages.parseUpdateMember(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0));
         assertEq(uint(decodedPoolId), uint(2));
         assertEq(decodedTrancheId, hex"811acd5b3f17c06841c7e41e9e04cb1b");
@@ -151,17 +158,7 @@ contract MessagesTest is Test {
             uint64(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0).indexUint(57, 8)),
             uint(1706260138)
         );
-
-
     }
-
-//    function testUpdateMemberDecoding() public {
-//        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint256 decodedValidUntil) = ConnectorMessages.parseUpdateMember(fromHex("04000000000000000500000000000000000000000000000009225ef95fa90f4f7938a5b34234d14768cb4263dd0000000000000000000000000000000000000000000000000000000062d118c9").ref(0));
-//        assertEq(uint(decodedPoolId), uint(5));
-//        assertEq(decodedTrancheId, toBytes16(fromHex("010000000000000003")));
-//        assertEq(decodedUser, 0x225ef95fa90f4F7938A5b34234d14768cB4263dd);
-//        assertEq(decodedValidUntil, uint(1657870537));
-//    }
 
     function testUpdateMemberEquivalence(
         uint64 poolId,

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -106,33 +106,83 @@ contract MessagesTest is Test {
 //    function testUpdateMemberEncodingThatFailed() public {
 //        assertEq(
 //            ConnectorMessages.formatUpdateMember(2, toBytes16(fromHex("811acd5b3f17c06841c7e41e9e04cb1b")), address(0x1231231231231231231231231231231231231231), 1706260138),
-//            fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b1231231231231231231231231231231231231231231231231231231231231231aa76b36500000000")
+//            fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA")
 //        );
 //    }
 
-//
-
-    function testParts() public {
-        (bytes16 decodedTrancheId) = ConnectorMessages.parseTrancheId(fromHex("811acd5b3f17c06841c7e41e9e04cb1b").ref(0));
-        assertEq(decodedTrancheId, toBytes16(fromHex("811acd5b3f17c06841c7e41e9e04cb1b")));
+    function testUpdateMemberDecodingThatFailed() public {
+        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint64 decodedValidUntil) = ConnectorMessages.parseUpdateMemberDebug(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0));
+        assertEq(uint(decodedPoolId), uint(2));
+        assertEq(decodedTrancheId, hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        assertEq(decodedUser, 0x1231231231231231231231231231231231231231);
+        assertEq(decodedValidUntil, uint(1706260138));
     }
 
-//    function testUpdateMemberDecodingThatFailed() public {
-//        (uint64 decodedPoolId, bytes16 decodedTrancheId) = ConnectorMessages.parseUpdateMemberDebug(fromHex("04 0000000000000002 811acd5b3f17c06841c7e41e9e04cb1b 1231231231231231231231231231231231231231231231231231231231231231aa76b36500000000").ref(0));
-//
-////        assertEq(uint(decodedPoolId), uint(2));
-//        assertEq(decodedTrancheId,  toBytes16(fromHex("010000000000000064"))); // toBytes16(fromHex("811acd5b3f17c06841c7e41e9e04cb1b"))); //c7e41e9e04cb1b")));
-////        assertEq(decodedUser, 0x1231231231231231231231231231231231231231);
-////        assertEq(decodedValidUntil, uint(1657870537));
+    function testPlayground() public {
+        // Works
+        assertEq(
+            fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0).index(9, 16),
+            hex"811acd5b3f17c06841c7e41e9e04cb1b"
+        );
+
+        // Works
+        assertEq(
+            fromHex("811acd5b3f17c06841c7e41e9e04cb1b").ref(0).index(0, 16),
+            hex"811acd5b3f17c06841c7e41e9e04cb1b"
+        );
+
+        // Works
+        assertEq(
+            bytes16(fromHex("811acd5b3f17c06841c7e41e9e04cb1b").ref(0).index(0, 16)),
+            bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b")
+        );
+
+        // Works
+        assertEq(
+            fromHex("811acd5b3f17c06841c7e41e9e04cb1b"),
+            hex"811acd5b3f17c06841c7e41e9e04cb1b"
+        );
+
+        // Works
+        assertEq(
+            toBytes16(fromHex("811acd5b3f17c06841c7e41e9e04cb1b")),
+            toBytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b")
+        );
+
+        // Address - if it were 32 bytes
+        assertEq(
+            fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0).index(25, 32),
+            hex"1231231231231231231231231231231231231231231231231231231231231231"
+        );
+
+        // Address - read 32 bytes but convert to 20 bytes
+        assertEq(
+            address(bytes20(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0).index(25, 32))),
+            0x1231231231231231231231231231231231231231
+        );
+
+        // Address - read bytes bytes and coerce convert to 20 bytes
+        assertEq(
+            address(bytes20(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0).index(25, 20))),
+            0x1231231231231231231231231231231231231231
+        );
+
+        // ValidUntil - read as uint
+        assertEq(
+            uint64(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0).indexUint(57, 8)),
+            uint(1706260138)
+        );
+
+
+    }
+
+//    function testUpdateMemberDecoding() public {
+//        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint256 decodedValidUntil) = ConnectorMessages.parseUpdateMember(fromHex("04000000000000000500000000000000000000000000000009225ef95fa90f4f7938a5b34234d14768cb4263dd0000000000000000000000000000000000000000000000000000000062d118c9").ref(0));
+//        assertEq(uint(decodedPoolId), uint(5));
+//        assertEq(decodedTrancheId, toBytes16(fromHex("010000000000000003")));
+//        assertEq(decodedUser, 0x225ef95fa90f4F7938A5b34234d14768cB4263dd);
+//        assertEq(decodedValidUntil, uint(1657870537));
 //    }
-
-    function testUpdateMemberDecoding() public {
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint256 decodedValidUntil) = ConnectorMessages.parseUpdateMember(fromHex("04000000000000000500000000000000000000000000000009225ef95fa90f4f7938a5b34234d14768cb4263dd0000000000000000000000000000000000000000000000000000000062d118c9").ref(0));
-        assertEq(uint(decodedPoolId), uint(5));
-        assertEq(decodedTrancheId, toBytes16(fromHex("010000000000000003")));
-        assertEq(decodedUser, 0x225ef95fa90f4F7938A5b34234d14768cB4263dd);
-        assertEq(decodedValidUntil, uint(1657870537));
-    }
 
     function testUpdateMemberEquivalence(
         uint64 poolId,

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -111,7 +111,7 @@ contract MessagesTest is Test {
 //    }
 
     function testUpdateMemberDecodingThatFailed() public {
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint64 decodedValidUntil) = ConnectorMessages.parseUpdateMemberDebug(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0));
+        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint64 decodedValidUntil) = ConnectorMessages.parseUpdateMember(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0));
         assertEq(uint(decodedPoolId), uint(2));
         assertEq(decodedTrancheId, hex"811acd5b3f17c06841c7e41e9e04cb1b");
         assertEq(decodedUser, 0x1231231231231231231231231231231231231231);
@@ -188,24 +188,24 @@ contract MessagesTest is Test {
         uint64 poolId,
         bytes16 trancheId,
         address user,
-        uint256 amount
+        uint64 validUntil
     ) public {
         bytes memory _message = ConnectorMessages.formatUpdateMember(
             poolId,
             trancheId,
             user,
-            amount
+            validUntil
         );
         (
             uint64 decodedPoolId,
             bytes16 decodedTrancheId,
             address decodedUser,
-            uint256 decodedAmount
+            uint256 decodedValidUntil
         ) = ConnectorMessages.parseUpdateMember(_message.ref(0));
         assertEq(uint256(decodedPoolId), uint256(poolId));
         assertEq(decodedTrancheId, trancheId);
         assertEq(decodedUser, user);
-        assertEq(decodedAmount, amount);
+        assertEq(decodedValidUntil, validUntil);
     }
 
     function testUpdateTokenPriceEncoding() public {

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -120,12 +120,12 @@ contract MessagesTest is Test {
             uint64 decodedPoolId,
             bytes16 decodedTrancheId,
             address decodedUser,
-            uint256 decodedValidUntil
+            uint64 decodedValidUntil
         ) = ConnectorMessages.parseUpdateMember(_message.ref(0));
-        assertEq(uint256(decodedPoolId), uint256(poolId));
+        assertEq(uint(decodedPoolId), uint(poolId));
         assertEq(decodedTrancheId, trancheId);
         assertEq(decodedUser, user);
-        assertEq(decodedValidUntil, validUntil);
+        assertEq(uint(decodedValidUntil), uint(validUntil));
     }
 
     function testUpdateTokenPriceEncoding() public {

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -104,62 +104,6 @@ contract MessagesTest is Test {
         assertEq(decodedValidUntil, uint(1706260138));
     }
 
-    function testPlayground() public {
-        // Works
-        assertEq(
-            fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0).index(9, 16),
-            hex"811acd5b3f17c06841c7e41e9e04cb1b"
-        );
-
-        // Works
-        assertEq(
-            fromHex("811acd5b3f17c06841c7e41e9e04cb1b").ref(0).index(0, 16),
-            hex"811acd5b3f17c06841c7e41e9e04cb1b"
-        );
-
-        // Works
-        assertEq(
-            bytes16(fromHex("811acd5b3f17c06841c7e41e9e04cb1b").ref(0).index(0, 16)),
-            bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b")
-        );
-
-        // Works
-        assertEq(
-            fromHex("811acd5b3f17c06841c7e41e9e04cb1b"),
-            hex"811acd5b3f17c06841c7e41e9e04cb1b"
-        );
-
-        // Works
-        assertEq(
-            toBytes16(fromHex("811acd5b3f17c06841c7e41e9e04cb1b")),
-            toBytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b")
-        );
-
-        // Address - if it were 32 bytes
-        assertEq(
-            fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0).index(25, 32),
-            hex"1231231231231231231231231231231231231231231231231231231231231231"
-        );
-
-        // Address - read 32 bytes but convert to 20 bytes
-        assertEq(
-            address(bytes20(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0).index(25, 32))),
-            0x1231231231231231231231231231231231231231
-        );
-
-        // Address - read bytes bytes and coerce convert to 20 bytes
-        assertEq(
-            address(bytes20(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0).index(25, 20))),
-            0x1231231231231231231231231231231231231231
-        );
-
-        // ValidUntil - read as uint
-        assertEq(
-            uint64(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0).indexUint(57, 8)),
-            uint(1706260138)
-        );
-    }
-
     function testUpdateMemberEquivalence(
         uint64 poolId,
         bytes16 trancheId,

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -89,12 +89,42 @@ contract MessagesTest is Test {
         assertEq(decodedTokenSymbol, bytes32ToString(stringToBytes32(tokenSymbol)));
     }
 
-    function testUpdateMemberEncoding() public {
-        assertEq(
-            ConnectorMessages.formatUpdateMember(5, toBytes16(fromHex("010000000000000003")), 0x225ef95fa90f4F7938A5b34234d14768cB4263dd, 1657870537), 
-            fromHex("04000000000000000500000000000000000000000000000009225ef95fa90f4f7938a5b34234d14768cb4263dd0000000000000000000000000000000000000000000000000000000062d118c9")
-            );
+//    function testDecodeValidUntil() public {
+//        assertEq(
+//            uint256(bytes29("aa76b36500000000").ref(0).index(0, 7)),
+//            1657870537
+//        );
+//    }
+
+//    function testUpdateMemberEncoding() public {
+//        assertEq(
+//            ConnectorMessages.formatUpdateMember(5, toBytes16(fromHex("010000000000000003")), 0x225ef95fa90f4F7938A5b34234d14768cB4263dd, 1657870537),
+//            fromHex("04000000000000000500000000000000000000000000000009225ef95fa90f4f7938a5b34234d14768cb4263dd0000000000000000000000000000000000000000000000000000000062d118c9")
+//            );
+//    }
+
+//    function testUpdateMemberEncodingThatFailed() public {
+//        assertEq(
+//            ConnectorMessages.formatUpdateMember(2, toBytes16(fromHex("811acd5b3f17c06841c7e41e9e04cb1b")), address(0x1231231231231231231231231231231231231231), 1706260138),
+//            fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b1231231231231231231231231231231231231231231231231231231231231231aa76b36500000000")
+//        );
+//    }
+
+//
+
+    function testParts() public {
+        (bytes16 decodedTrancheId) = ConnectorMessages.parseTrancheId(fromHex("811acd5b3f17c06841c7e41e9e04cb1b").ref(0));
+        assertEq(decodedTrancheId, toBytes16(fromHex("811acd5b3f17c06841c7e41e9e04cb1b")));
     }
+
+//    function testUpdateMemberDecodingThatFailed() public {
+//        (uint64 decodedPoolId, bytes16 decodedTrancheId) = ConnectorMessages.parseUpdateMemberDebug(fromHex("04 0000000000000002 811acd5b3f17c06841c7e41e9e04cb1b 1231231231231231231231231231231231231231231231231231231231231231aa76b36500000000").ref(0));
+//
+////        assertEq(uint(decodedPoolId), uint(2));
+//        assertEq(decodedTrancheId,  toBytes16(fromHex("010000000000000064"))); // toBytes16(fromHex("811acd5b3f17c06841c7e41e9e04cb1b"))); //c7e41e9e04cb1b")));
+////        assertEq(decodedUser, 0x1231231231231231231231231231231231231231);
+////        assertEq(decodedValidUntil, uint(1657870537));
+//    }
 
     function testUpdateMemberDecoding() public {
         (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint256 decodedValidUntil) = ConnectorMessages.parseUpdateMember(fromHex("04000000000000000500000000000000000000000000000009225ef95fa90f4f7938a5b34234d14768cb4263dd0000000000000000000000000000000000000000000000000000000062d118c9").ref(0));

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -89,27 +89,6 @@ contract MessagesTest is Test {
         assertEq(decodedTokenSymbol, bytes32ToString(stringToBytes32(tokenSymbol)));
     }
 
-//    function testDecodeValidUntil() public {
-//        assertEq(
-//            uint256(bytes29("aa76b36500000000").ref(0).index(0, 7)),
-//            1657870537
-//        );
-//    }
-
-//    function testUpdateMemberEncoding() public {
-//        assertEq(
-//            ConnectorMessages.formatUpdateMember(5, toBytes16(fromHex("010000000000000003")), 0x225ef95fa90f4F7938A5b34234d14768cB4263dd, 1657870537),
-//            fromHex("04000000000000000500000000000000000000000000000009225ef95fa90f4f7938a5b34234d14768cb4263dd0000000000000000000000000000000000000000000000000000000062d118c9")
-//            );
-//    }
-
-//    function testUpdateMemberEncodingThatFailed() public {
-//        assertEq(
-//            ConnectorMessages.formatUpdateMember(2, toBytes16(fromHex("811acd5b3f17c06841c7e41e9e04cb1b")), address(0x1231231231231231231231231231231231231231), 1706260138),
-//            fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA")
-//        );
-//    }
-
     function testUpdateMemberDecodingThatFailed() public {
         (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint64 decodedValidUntil) = ConnectorMessages.parseUpdateMember(fromHex("040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065B376AA").ref(0));
         assertEq(uint(decodedPoolId), uint(2));

--- a/test/mock/MockHomeConnector.sol
+++ b/test/mock/MockHomeConnector.sol
@@ -43,8 +43,8 @@ contract MockHomeConnector is Test {
     }
 
 
-    function updateMember(uint64 poolId, bytes16 trancheId, address user, uint256 amount) public {
-        bytes memory _message = ConnectorMessages.formatUpdateMember(poolId, trancheId, user, amount);
+    function updateMember(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) public {
+        bytes memory _message = ConnectorMessages.formatUpdateMember(poolId, trancheId, user, validUntil);
         router.handle(_message);
     }
 


### PR DESCRIPTION
When testing the latest contract revision in `add-withdaw-deposit`, `UpdateMember` failed with a parsing error.
Here we fix all of these issues and improve the tests to verify the correctness of those changes. On the cent-chain side we tweak the encoding of the `UpdateMember.validUntil` to little endian so that it is parsed correctly on this side of the system.