### PR TITLE
Fine-tune transfers encoding, decoding, and tests

### DIFF
--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -157,17 +157,11 @@ library ConnectorMessages {
      * 0: call type (uint8 = 1 byte)
      * 1-8: poolId (uint64 = 8 bytes)
      * 9-24: trancheId (16 bytes)
-     * 25-56: user (Ethereum address, 20 bytes)
+     * 25-56: user (Ethereum address, 20 bytes - Skip last 12 bytes for 32-byte address compatibility)
      * 57-72: amount (uint128 = 16 bytes)
      * 73-82: domain (Domain = 9 bytes)
      */
     function formatTransfer(uint64 poolId, bytes16 trancheId, address user, uint128 amount, bytes9 destinationDomain) internal pure returns (bytes memory) {
-        // 1 byte - call type
-        // 8 bytes - poolId
-        // 16 bytes - TrancheId
-        // 32 bytes - Address
-        // 16 bytes - Amount
-        // 9 bytes - Domain
         return abi.encodePacked(uint8(Call.Transfer), poolId, trancheId, user, bytes(hex"000000000000000000000000"), amount, destinationDomain);
     }
 
@@ -176,18 +170,11 @@ library ConnectorMessages {
     }
 
     function parseTransfer(bytes29 _msg) internal pure returns (uint64 poolId, bytes16 trancheId, address user, uint128 amount, bytes9 encodedDomain) {
-        // 8 bytes - Pool id
-        // 16 bytes - tranche Id
-
-        // 9 bytes - domain
-        // 32 bytes - address
-        // 16 bytes - Amount (????)
-
         poolId = uint64(_msg.indexUint(1, 8));
         trancheId = bytes16(_msg.index(9, 16));
         user = address(bytes20(_msg.index(25, 20)));
-        amount = uint128(_msg.indexUint(45, 16));
-        encodedDomain = bytes9(_msg.index(45, 9));
+        amount = uint128(_msg.indexUint(57, 16));
+        encodedDomain = bytes9(_msg.index(73, 9));
     }
 
     function formatDomain(Domain domain) public pure returns (bytes9) {

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -156,24 +156,38 @@ library ConnectorMessages {
      * 
      * 0: call type (uint8 = 1 byte)
      * 1-8: poolId (uint64 = 8 bytes)
-     * 9-25: trancheId (16 bytes)
-     * 26-46: user (Ethereum address, 20 bytes)
-     * 47-78: amount (uint256 = 32 bytes)
-     * 
+     * 9-24: trancheId (16 bytes)
+     * 25-56: user (Ethereum address, 20 bytes)
+     * 57-72: amount (uint128 = 16 bytes)
+     * 73-82: domain (Domain = 9 bytes)
      */
-    function formatTransfer(uint64 poolId, bytes16 trancheId, address user, uint256 amount, bytes9 destinationDomain) internal pure returns (bytes memory) {
-        return abi.encodePacked(uint8(Call.Transfer), poolId, trancheId, user, amount, destinationDomain);
+    function formatTransfer(uint64 poolId, bytes16 trancheId, address user, uint128 amount, bytes9 destinationDomain) internal pure returns (bytes memory) {
+        // 1 byte - call type
+        // 8 bytes - poolId
+        // 16 bytes - TrancheId
+        // 32 bytes - Address
+        // 16 bytes - Amount
+        // 9 bytes - Domain
+        return abi.encodePacked(uint8(Call.Transfer), poolId, trancheId, user, bytes(hex"000000000000000000000000"), amount, destinationDomain);
     }
 
     function isTransfer(bytes29 _msg) internal pure returns (bool) {
         return messageType(_msg) == Call.Transfer;
     }
 
-    function parseTransfer(bytes29 _msg) internal pure returns (uint64 poolId, bytes16 trancheId, address user, uint256 amount) {
+    function parseTransfer(bytes29 _msg) internal pure returns (uint64 poolId, bytes16 trancheId, address user, uint128 amount, bytes9 encodedDomain) {
+        // 8 bytes - Pool id
+        // 16 bytes - tranche Id
+
+        // 9 bytes - domain
+        // 32 bytes - address
+        // 16 bytes - Amount (????)
+
         poolId = uint64(_msg.indexUint(1, 8));
         trancheId = bytes16(_msg.index(9, 16));
         user = address(bytes20(_msg.index(25, 20)));
-        amount = uint256(_msg.index(45, 32));
+        amount = uint128(_msg.indexUint(45, 16));
+        encodedDomain = bytes9(_msg.index(45, 9));
     }
 
     function formatDomain(Domain domain) public pure returns (bytes9) {

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -159,7 +159,7 @@ library ConnectorMessages {
      * 9-24: trancheId (16 bytes)
      * 25-56: user (Ethereum address, 20 bytes - Skip last 12 bytes for 32-byte address compatibility)
      * 57-72: amount (uint128 = 16 bytes)
-     * 73-82: domain (Domain = 9 bytes)
+     * 73-81: domain (Domain = 9 bytes)
      */
     function formatTransfer(uint64 poolId, bytes16 trancheId, address user, uint128 amount, bytes9 destinationDomain) internal pure returns (bytes memory) {
         return abi.encodePacked(uint8(Call.Transfer), poolId, trancheId, user, bytes(hex"000000000000000000000000"), amount, destinationDomain);

--- a/src/routers/xcm/Router.sol
+++ b/src/routers/xcm/Router.sol
@@ -56,7 +56,7 @@ contract ConnectorXCMRouter {
             (uint64 poolId, bytes16 trancheId, uint128 price) = ConnectorMessages.parseUpdateTokenPrice(_msg);
             connector.updateTokenPrice(poolId, trancheId, price);
         } else if (ConnectorMessages.isTransfer(_msg)) {
-            (uint64 poolId, bytes16 trancheId, address user, uint256 amount) = ConnectorMessages.parseTransfer(_msg);
+            (uint64 poolId, bytes16 trancheId, address user, uint256 amount, bytes9 _decodedDomain) = ConnectorMessages.parseTransfer(_msg);
             connector.handleTransfer(poolId, trancheId, user, amount);
         } else {
             require(false, "invalid-message");

--- a/test/Connector.t.sol
+++ b/test/Connector.t.sol
@@ -179,7 +179,7 @@ contract ConnectorTest is Test {
         bridgedConnector.updateTokenPrice(poolId, trancheId, price);
      }
 
-    function testTransferCentrifuge(uint64 poolId, string memory tokenName, string memory tokenSymbol, bytes16 trancheId, uint128 price, address user, uint256 amount, uint64 validUntil) public {
+    function testTransferCentrifuge(uint64 poolId, string memory tokenName, string memory tokenSymbol, bytes16 trancheId, uint128 price, address user, uint128 amount, uint64 validUntil) public {
         vm.assume(validUntil > block.timestamp + 7 days);
         // 0. Add Pool
         homeConnector.addPool(poolId);
@@ -200,7 +200,7 @@ contract ConnectorTest is Test {
         assertEq(ERC20Like(token).balanceOf(user), amount);
     }
 
-    function testTransferEVM(uint64 poolId, string memory tokenName, string memory tokenSymbol, bytes16 trancheId, uint128 price, uint64 destinationChainId, address user, uint256 amount, uint64 validUntil) public {
+    function testTransferEVM(uint64 poolId, string memory tokenName, string memory tokenSymbol, bytes16 trancheId, uint128 price, uint64 destinationChainId, address user, uint128 amount, uint64 validUntil) public {
         vm.assume(validUntil > block.timestamp + 7 days);
         // 0. Add Pool
         homeConnector.addPool(poolId);
@@ -221,7 +221,7 @@ contract ConnectorTest is Test {
         assertEq(ERC20Like(token).balanceOf(user), amount);
     }
 
-    function testTransferEVMWithoutMemberFails(uint64 poolId, string memory tokenName, string memory tokenSymbol, bytes16 trancheId, uint128 price, uint64 destinationChainId, address user, uint256 amount, uint64 validUntil) public {
+    function testTransferEVMWithoutMemberFails(uint64 poolId, string memory tokenName, string memory tokenSymbol, bytes16 trancheId, uint128 price, uint64 destinationChainId, address user, uint128 amount, uint64 validUntil) public {
         vm.assume(validUntil > block.timestamp + 7 days);
         // 0. Add Pool
         homeConnector.addPool(poolId);

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -179,23 +179,26 @@ contract MessagesTest is Test {
         );
     }
 
-//    // TODO: replace payload with real msg from Cent chain
-//    function testTransferDecoding() public {
-//        (uint64 poolId, bytes16 trancheId, address user, uint256 amount, bytes9 decodedDomain) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312310000000000000000000000000000000000000000033b2e3c9fd0803ce8000000000000000000000000").ref(0));
-//        assertEq(uint(poolId), uint(1));
-//        assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
-//        assertEq(user, 0x1231231231231231231231231231231231231231);
-//        assertEq(amount, uint(1000000000000000000000000000));
-//    }
-//
-//    function testTransferEquivalence(uint64 poolId, bytes16 trancheId, address user, uint128 amount, uint64 destinationChainId) public {
-//        bytes memory _message = ConnectorMessages.formatTransfer(poolId, trancheId, user, amount, ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, destinationChainId));
-//        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint256 decodedAmount, bytes9 decodedDomain) = ConnectorMessages.parseTransfer(_message.ref(0));
-//        assertEq(uint(decodedPoolId), uint(poolId));
-//        assertEq(decodedTrancheId, trancheId);
-//        assertEq(decodedUser, user);
-//        assertEq(decodedAmount, amount);
-//    }
+    // TODO: replace payload with real msg from Cent chain
+    function testTransferDecoding() public {
+        (uint64 poolId, bytes16 trancheId, address user, uint256 amount, bytes9 decodedDomain) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000000000000000000000").ref(0));
+        assertEq(uint(poolId), uint(1));
+        assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
+        assertEq(user, 0x1231231231231231231231231231231231231231);
+        assertEq(amount, uint(1000000000000000000000000000));
+        assertEq(decodedDomain, bytes9(hex"000000000000000000"));
+    }
+
+    function testTransferEquivalence(uint64 poolId, bytes16 trancheId, address user, uint128 amount, uint64 destinationChainId) public {
+        bytes9 inputEncodedDomain = ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, destinationChainId);
+        bytes memory _message = ConnectorMessages.formatTransfer(poolId, trancheId, user, amount, inputEncodedDomain);
+        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint256 decodedAmount, bytes9 encodedDomain) = ConnectorMessages.parseTransfer(_message.ref(0));
+        assertEq(uint(decodedPoolId), uint(poolId));
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedUser, user);
+        assertEq(decodedAmount, amount);
+        assertEq(encodedDomain, inputEncodedDomain);
+    }
 
     function testFormatDomainCentrifuge() public {
         assertEq(ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge), hex"000000000000000000");

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -174,28 +174,28 @@ contract MessagesTest is Test {
     // TODO: replace payload with real msg from Cent chain
     function testTransferEncoding() public {
         assertEq(
-            ConnectorMessages.formatTransfer(1, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"), 0x1231231231231231231231231231231231231231, 1000000000000000000000000000, bytes9(hex"000000000000000000")),
-            hex"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312310000000000000000000000000000000000000000033b2e3c9fd0803ce8000000000000000000000000"
-            );
+            ConnectorMessages.formatTransfer(1, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"), 0x1231231231231231231231231231231231231231, 1000000000000000000000000000, ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge)),
+            hex"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000000000000000000000"
+        );
     }
 
-    // TODO: replace payload with real msg from Cent chain
-    function testTransferDecoding() public {
-        (uint64 poolId, bytes16 trancheId, address user, uint256 amount) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312310000000000000000000000000000000000000000033b2e3c9fd0803ce8000000000000000000000000").ref(0));
-        assertEq(uint(poolId), uint(1));
-        assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
-        assertEq(user, 0x1231231231231231231231231231231231231231);
-        assertEq(amount, uint(1000000000000000000000000000));
-    }
-
-    function testTransferEquivalence(uint64 poolId, bytes16 trancheId, address user, uint256 amount, uint64 destinationChainId) public {
-        bytes memory _message = ConnectorMessages.formatTransfer(poolId, trancheId, user, amount, ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, destinationChainId));
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint256 decodedAmount) = ConnectorMessages.parseTransfer(_message.ref(0));
-        assertEq(uint(decodedPoolId), uint(poolId));
-        assertEq(decodedTrancheId, trancheId);
-        assertEq(decodedUser, user);
-        assertEq(decodedAmount, amount);
-    }
+//    // TODO: replace payload with real msg from Cent chain
+//    function testTransferDecoding() public {
+//        (uint64 poolId, bytes16 trancheId, address user, uint256 amount, bytes9 decodedDomain) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312310000000000000000000000000000000000000000033b2e3c9fd0803ce8000000000000000000000000").ref(0));
+//        assertEq(uint(poolId), uint(1));
+//        assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
+//        assertEq(user, 0x1231231231231231231231231231231231231231);
+//        assertEq(amount, uint(1000000000000000000000000000));
+//    }
+//
+//    function testTransferEquivalence(uint64 poolId, bytes16 trancheId, address user, uint128 amount, uint64 destinationChainId) public {
+//        bytes memory _message = ConnectorMessages.formatTransfer(poolId, trancheId, user, amount, ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, destinationChainId));
+//        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint256 decodedAmount, bytes9 decodedDomain) = ConnectorMessages.parseTransfer(_message.ref(0));
+//        assertEq(uint(decodedPoolId), uint(poolId));
+//        assertEq(decodedTrancheId, trancheId);
+//        assertEq(decodedUser, user);
+//        assertEq(decodedAmount, amount);
+//    }
 
     function testFormatDomainCentrifuge() public {
         assertEq(ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge), hex"000000000000000000");

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -171,16 +171,30 @@ contract MessagesTest is Test {
         assertEq(uint(decodedPrice), uint(price));
     }
 
-    // TODO: replace payload with real msg from Cent chain
-    function testTransferEncoding() public {
+    function testTransferToEvmDomainEncoding() public {
+        assertEq(
+            ConnectorMessages.formatTransfer(1, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"), 0x1231231231231231231231231231231231231231, 1000000000000000000000000000, ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, 1284)),
+            hex"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000010000000000000504"
+        );
+    }
+
+    function testTransferToEvmDomainDecoding() public {
+        (uint64 poolId, bytes16 trancheId, address user, uint256 amount, bytes9 decodedDomain) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000010000000000000504").ref(0));
+        assertEq(uint(poolId), uint(1));
+        assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
+        assertEq(user, 0x1231231231231231231231231231231231231231);
+        assertEq(amount, uint(1000000000000000000000000000));
+        assertEq(decodedDomain, bytes9(hex"010000000000000504"));
+    }
+
+    function testTransferToCentrifugeEncoding() public {
         assertEq(
             ConnectorMessages.formatTransfer(1, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"), 0x1231231231231231231231231231231231231231, 1000000000000000000000000000, ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge)),
             hex"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000000000000000000000"
         );
     }
 
-    // TODO: replace payload with real msg from Cent chain
-    function testTransferDecoding() public {
+    function testTransferToCentrifugeDecoding() public {
         (uint64 poolId, bytes16 trancheId, address user, uint256 amount, bytes9 decodedDomain) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000000000000000000000").ref(0));
         assertEq(uint(poolId), uint(1));
         assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));

--- a/test/mock/MockHomeConnector.sol
+++ b/test/mock/MockHomeConnector.sol
@@ -53,7 +53,7 @@ contract MockHomeConnector is Test {
         router.handle(_message);
     }
 
-    function transfer(uint64 poolId, bytes16 trancheId, address user, uint256 amount, bytes9 destinationDomain) public  {
+    function transfer(uint64 poolId, bytes16 trancheId, address user, uint128 amount, bytes9 destinationDomain) public  {
         bytes memory _message = ConnectorMessages.formatTransfer(poolId, trancheId, user, amount, destinationDomain);
         router.handle(_message);
     }


### PR DESCRIPTION
Here we align the encoding/decoding tests of the `Transfer` message using cent-chain generated messages. We fix some issues with the current encoding and decoding functions and extend the tests to cover more use cases.