### PR TITLE
Transfer: place `domain` before `user`

### DIFF
--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -161,8 +161,8 @@ library ConnectorMessages {
      * 57-72: amount (uint128 = 16 bytes)
      * 73-81: domain (Domain = 9 bytes)
      */
-    function formatTransfer(uint64 poolId, bytes16 trancheId, bytes9 destinationDomain, address user, uint128 amount) internal pure returns (bytes memory) {
-        return abi.encodePacked(uint8(Call.Transfer), poolId, trancheId, destinationDomain, user, bytes(hex"000000000000000000000000"), amount);
+    function formatTransfer(uint64 poolId, bytes16 trancheId, bytes9 destinationDomain, address destinationAddress, uint128 amount) internal pure returns (bytes memory) {
+        return abi.encodePacked(uint8(Call.Transfer), poolId, trancheId, destinationDomain, destinationAddress, bytes(hex"000000000000000000000000"), amount);
     }
 
     function isTransfer(bytes29 _msg) internal pure returns (bool) {

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -161,20 +161,20 @@ library ConnectorMessages {
      * 57-72: amount (uint128 = 16 bytes)
      * 73-81: domain (Domain = 9 bytes)
      */
-    function formatTransfer(uint64 poolId, bytes16 trancheId, address user, uint128 amount, bytes9 destinationDomain) internal pure returns (bytes memory) {
-        return abi.encodePacked(uint8(Call.Transfer), poolId, trancheId, user, bytes(hex"000000000000000000000000"), amount, destinationDomain);
+    function formatTransfer(uint64 poolId, bytes16 trancheId, bytes9 destinationDomain, address user, uint128 amount) internal pure returns (bytes memory) {
+        return abi.encodePacked(uint8(Call.Transfer), poolId, trancheId, destinationDomain, user, bytes(hex"000000000000000000000000"), amount);
     }
 
     function isTransfer(bytes29 _msg) internal pure returns (bool) {
         return messageType(_msg) == Call.Transfer;
     }
 
-    function parseTransfer(bytes29 _msg) internal pure returns (uint64 poolId, bytes16 trancheId, address user, uint128 amount, bytes9 encodedDomain) {
+    function parseTransfer(bytes29 _msg) internal pure returns (uint64 poolId, bytes16 trancheId, bytes9 encodedDomain, address user, uint128 amount) {
         poolId = uint64(_msg.indexUint(1, 8));
         trancheId = bytes16(_msg.index(9, 16));
-        user = address(bytes20(_msg.index(25, 20)));
-        amount = uint128(_msg.indexUint(57, 16));
-        encodedDomain = bytes9(_msg.index(73, 9));
+        encodedDomain = bytes9(_msg.index(25, 9));
+        user = address(bytes20(_msg.index(34, 20)));
+        amount = uint128(_msg.indexUint(66, 16));
     }
 
     function formatDomain(Domain domain) public pure returns (bytes9) {

--- a/src/routers/xcm/Router.sol
+++ b/src/routers/xcm/Router.sol
@@ -56,7 +56,7 @@ contract ConnectorXCMRouter {
             (uint64 poolId, bytes16 trancheId, uint128 price) = ConnectorMessages.parseUpdateTokenPrice(_msg);
             connector.updateTokenPrice(poolId, trancheId, price);
         } else if (ConnectorMessages.isTransfer(_msg)) {
-            (uint64 poolId, bytes16 trancheId, address user, uint256 amount, bytes9 _decodedDomain) = ConnectorMessages.parseTransfer(_msg);
+            (uint64 poolId, bytes16 trancheId,, address user, uint256 amount) = ConnectorMessages.parseTransfer(_msg);
             connector.handleTransfer(poolId, trancheId, user, amount);
         } else {
             require(false, "invalid-message");

--- a/test/Connector.t.sol
+++ b/test/Connector.t.sol
@@ -223,7 +223,7 @@ contract ConnectorTest is Test {
         
         // 4. Transfer some tokens
         bytes9 encodedDomain = ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge);
-        homeConnector.transfer(poolId, trancheId, user, amount, encodedDomain);
+        homeConnector.transfer(poolId, trancheId, encodedDomain, user, amount);
         (address token,,,,) = bridgedConnector.tranches(poolId, trancheId);
         assertEq(ERC20Like(token).balanceOf(user), amount);
     }
@@ -244,7 +244,7 @@ contract ConnectorTest is Test {
         
         // 4. Transfer some tokens
         bytes9 encodedDomain = ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, destinationChainId);
-        homeConnector.transfer(poolId, trancheId, user, amount, encodedDomain);
+        homeConnector.transfer(poolId, trancheId, encodedDomain, user, amount);
         (address token,,,,) = bridgedConnector.tranches(poolId, trancheId);
         assertEq(ERC20Like(token).balanceOf(user), amount);
     }
@@ -263,7 +263,7 @@ contract ConnectorTest is Test {
         // 3. Transfer some tokens and expect revert
         bytes9 encodedDomain = ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, destinationChainId);
         vm.expectRevert(bytes("CentrifugeConnector/not-a-member"));
-        homeConnector.transfer(poolId, trancheId, user, amount, encodedDomain);
+        homeConnector.transfer(poolId, trancheId, encodedDomain, user, amount);
         (address token,,,,) = bridgedConnector.tranches(poolId, trancheId);
         assertEq(ERC20Like(token).balanceOf(user), 0);
     }

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -173,45 +173,45 @@ contract MessagesTest is Test {
 
     function testTransferToEvmDomainEncoding() public {
         assertEq(
-            ConnectorMessages.formatTransfer(1, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"), 0x1231231231231231231231231231231231231231, 1000000000000000000000000000, ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, 1284)),
-            hex"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000010000000000000504"
+            ConnectorMessages.formatTransfer(1, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"), ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, 1284), 0x1231231231231231231231231231231231231231, 1000000000000000000000000000),
+            hex"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b010000000000000504123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000"
         );
     }
 
     function testTransferToEvmDomainDecoding() public {
-        (uint64 poolId, bytes16 trancheId, address user, uint256 amount, bytes9 decodedDomain) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000010000000000000504").ref(0));
+        (uint64 poolId, bytes16 trancheId, bytes9 decodedDomain, address user, uint256 amount) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b010000000000000504123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000").ref(0));
         assertEq(uint(poolId), uint(1));
         assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
+        assertEq(decodedDomain, bytes9(hex"010000000000000504"));
         assertEq(user, 0x1231231231231231231231231231231231231231);
         assertEq(amount, uint(1000000000000000000000000000));
-        assertEq(decodedDomain, bytes9(hex"010000000000000504"));
     }
 
     function testTransferToCentrifugeEncoding() public {
         assertEq(
-            ConnectorMessages.formatTransfer(1, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"), 0x1231231231231231231231231231231231231231, 1000000000000000000000000000, ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge)),
-            hex"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000000000000000000000"
+            ConnectorMessages.formatTransfer(1, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"), ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge), 0x1231231231231231231231231231231231231231, 1000000000000000000000000000),
+            hex"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b000000000000000000123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000"
         );
     }
 
     function testTransferToCentrifugeDecoding() public {
-        (uint64 poolId, bytes16 trancheId, address user, uint256 amount, bytes9 decodedDomain) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000000000000000000000").ref(0));
+        (uint64 poolId, bytes16 trancheId, bytes9 decodedDomain, address user, uint256 amount) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b000000000000000000123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000").ref(0));
         assertEq(uint(poolId), uint(1));
         assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
+        assertEq(decodedDomain, bytes9(hex"000000000000000000"));
         assertEq(user, 0x1231231231231231231231231231231231231231);
         assertEq(amount, uint(1000000000000000000000000000));
-        assertEq(decodedDomain, bytes9(hex"000000000000000000"));
     }
 
     function testTransferEquivalence(uint64 poolId, bytes16 trancheId, address user, uint128 amount, uint64 destinationChainId) public {
         bytes9 inputEncodedDomain = ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, destinationChainId);
-        bytes memory _message = ConnectorMessages.formatTransfer(poolId, trancheId, user, amount, inputEncodedDomain);
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint256 decodedAmount, bytes9 encodedDomain) = ConnectorMessages.parseTransfer(_message.ref(0));
+        bytes memory _message = ConnectorMessages.formatTransfer(poolId, trancheId, inputEncodedDomain, user, amount);
+        (uint64 decodedPoolId, bytes16 decodedTrancheId,  bytes9 encodedDomain, address decodedUser, uint256 decodedAmount) = ConnectorMessages.parseTransfer(_message.ref(0));
         assertEq(uint(decodedPoolId), uint(poolId));
         assertEq(decodedTrancheId, trancheId);
+        assertEq(encodedDomain, inputEncodedDomain);
         assertEq(decodedUser, user);
         assertEq(decodedAmount, amount);
-        assertEq(encodedDomain, inputEncodedDomain);
     }
 
     function testFormatDomainCentrifuge() public {

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -179,10 +179,10 @@ contract MessagesTest is Test {
     }
 
     function testTransferToEvmDomainDecoding() public {
-        (uint64 poolId, bytes16 trancheId, bytes9 decodedDomain, address user, uint256 amount) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b010000000000000504123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000").ref(0));
+        (uint64 poolId, bytes16 trancheId, bytes9 domain, address user, uint256 amount) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b010000000000000504123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000").ref(0));
         assertEq(uint(poolId), uint(1));
         assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
-        assertEq(decodedDomain, bytes9(hex"010000000000000504"));
+        assertEq(domain, ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, 1284));
         assertEq(user, 0x1231231231231231231231231231231231231231);
         assertEq(amount, uint(1000000000000000000000000000));
     }
@@ -195,10 +195,10 @@ contract MessagesTest is Test {
     }
 
     function testTransferToCentrifugeDecoding() public {
-        (uint64 poolId, bytes16 trancheId, bytes9 decodedDomain, address user, uint256 amount) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b000000000000000000123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000").ref(0));
+        (uint64 poolId, bytes16 trancheId, bytes9 domain, address user, uint256 amount) = ConnectorMessages.parseTransfer(fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b000000000000000000123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000").ref(0));
         assertEq(uint(poolId), uint(1));
         assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
-        assertEq(decodedDomain, bytes9(hex"000000000000000000"));
+        assertEq(domain, ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge));
         assertEq(user, 0x1231231231231231231231231231231231231231);
         assertEq(amount, uint(1000000000000000000000000000));
     }

--- a/test/mock/MockHomeConnector.sol
+++ b/test/mock/MockHomeConnector.sol
@@ -53,8 +53,8 @@ contract MockHomeConnector is Test {
         router.handle(_message);
     }
 
-    function transfer(uint64 poolId, bytes16 trancheId, bytes9 destinationDomain, address user, uint128 amount) public  {
-        bytes memory _message = ConnectorMessages.formatTransfer(poolId, trancheId, destinationDomain, user, amount);
+    function transfer(uint64 poolId, bytes16 trancheId, bytes9 destinationDomain, address destinationAddress, uint128 amount) public  {
+        bytes memory _message = ConnectorMessages.formatTransfer(poolId, trancheId, destinationDomain, destinationAddress, amount);
         router.handle(_message);
     }
 

--- a/test/mock/MockHomeConnector.sol
+++ b/test/mock/MockHomeConnector.sol
@@ -53,8 +53,8 @@ contract MockHomeConnector is Test {
         router.handle(_message);
     }
 
-    function transfer(uint64 poolId, bytes16 trancheId, address user, uint128 amount, bytes9 destinationDomain) public  {
-        bytes memory _message = ConnectorMessages.formatTransfer(poolId, trancheId, user, amount, destinationDomain);
+    function transfer(uint64 poolId, bytes16 trancheId, bytes9 destinationDomain, address user, uint128 amount) public  {
+        bytes memory _message = ConnectorMessages.formatTransfer(poolId, trancheId, destinationDomain, user, amount);
         router.handle(_message);
     }
 


### PR DESCRIPTION
Match the cent-chain changes moving `domain` before `address`. We also update the tests with cent-chain generated transfer messages. 