### PR TITLE
Support transfers to 32-byte destination address

### DIFF
--- a/src/Connector.sol
+++ b/src/Connector.sol
@@ -80,15 +80,9 @@ contract CentrifugeConnector {
     }
 
     // --- Outgoing message handling ---
-    function transfer(
-        uint64 poolId,
-        bytes16 trancheId,
-        ConnectorMessages.Domain domain,
-        bytes32 destinationAddress,
-        uint128 amount
-    ) public {
-        require(domain == ConnectorMessages.Domain.Centrifuge, "CentrifugeConnector/invalid-domain");
-
+    function transferToCentrifuge(uint64 poolId, bytes16 trancheId, bytes32 destinationAddress, uint128 amount)
+        public
+    {
         RestrictedTokenLike token = RestrictedTokenLike(tranches[poolId][trancheId].token);
         require(address(token) != address(0), "CentrifugeConnector/unknown-token");
 
@@ -97,7 +91,11 @@ contract CentrifugeConnector {
 
         router.send(
             ConnectorMessages.formatTransfer(
-                poolId, trancheId, ConnectorMessages.formatDomain(domain), destinationAddress, amount
+                poolId,
+                trancheId,
+                ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge),
+                destinationAddress,
+                amount
             )
         );
     }

--- a/src/Connector.sol
+++ b/src/Connector.sol
@@ -84,7 +84,7 @@ contract CentrifugeConnector {
         uint64 poolId,
         bytes16 trancheId,
         ConnectorMessages.Domain domain,
-        address destinationAddress,
+        bytes32 destinationAddress,
         uint128 amount
     ) public {
         require(domain == ConnectorMessages.Domain.Centrifuge, "CentrifugeConnector/invalid-domain");

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -216,8 +216,7 @@ library ConnectorMessages {
         address destinationAddress,
         uint128 amount
     ) internal pure returns (bytes memory) {
-        return
-            formatTransfer(poolId, trancheId, destinationDomain, bytes32(bytes20(destinationAddress)), amount);
+        return formatTransfer(poolId, trancheId, destinationDomain, bytes32(bytes20(destinationAddress)), amount);
     }
 
     function isTransfer(bytes29 _msg) internal pure returns (bool) {

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -205,8 +205,8 @@ library ConnectorMessages {
         return abi.encodePacked(uint8(Call.Transfer), poolId, trancheId, destinationDomain, destinationAddress, amount);
     }
 
-    // Format a transfer to an Evm address
-    // Note: This is a convenience function to dry the cast from `address` to `bytes32`
+    // Format a transfer to an EVM domain
+    // Note: This is an overload function to dry the cast from `address` to `bytes32`
     // for the `destinationAddress` field by using the default `formatTransfer` implementation
     // by appending 12 zeros to the evm-based `destinationAddress`.
     function formatTransfer(
@@ -217,7 +217,7 @@ library ConnectorMessages {
         uint128 amount
     ) internal pure returns (bytes memory) {
         return
-            formatTransfer(poolId, trancheId, destinationDomain, bytes32(abi.encodePacked(destinationAddress)), amount);
+            formatTransfer(poolId, trancheId, destinationDomain, bytes32(bytes20(destinationAddress)), amount);
     }
 
     function isTransfer(bytes29 _msg) internal pure returns (bool) {

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -225,9 +225,9 @@ library ConnectorMessages {
 
     // Parse a Transfer to a Centrifuge-based `destinationAddress` (32-byte long)
     function parseTransfer32(bytes29 _msg)
-    internal
-    pure
-    returns (uint64 poolId, bytes16 trancheId, bytes9 encodedDomain, bytes32 destinationAddress, uint128 amount)
+        internal
+        pure
+        returns (uint64 poolId, bytes16 trancheId, bytes9 encodedDomain, bytes32 destinationAddress, uint128 amount)
     {
         poolId = uint64(_msg.indexUint(1, 8));
         trancheId = bytes16(_msg.index(9, 16));
@@ -242,7 +242,8 @@ library ConnectorMessages {
         pure
         returns (uint64 poolId, bytes16 trancheId, bytes9 encodedDomain, address destinationAddress, uint128 amount)
     {
-        (uint64 poolId_, bytes16 trancheId_, bytes9 encodedDomain_, bytes32 destinationAddress32, uint128 amount_) = parseTransfer32(_msg);
+        (uint64 poolId_, bytes16 trancheId_, bytes9 encodedDomain_, bytes32 destinationAddress32, uint128 amount_) =
+            parseTransfer32(_msg);
         destinationAddress = address(bytes20(destinationAddress32));
 
         return (poolId_, trancheId_, encodedDomain_, destinationAddress, amount_);

--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -216,13 +216,8 @@ library ConnectorMessages {
         address destinationAddress,
         uint128 amount
     ) internal pure returns (bytes memory) {
-        return formatTransfer(
-            poolId,
-            trancheId,
-            destinationDomain,
-            bytes32(abi.encodePacked(destinationAddress)),
-            amount
-        );
+        return
+            formatTransfer(poolId, trancheId, destinationDomain, bytes32(abi.encodePacked(destinationAddress)), amount);
     }
 
     function isTransfer(bytes29 _msg) internal pure returns (bool) {

--- a/src/routers/xcm/Router.sol
+++ b/src/routers/xcm/Router.sol
@@ -150,7 +150,7 @@ contract ConnectorXCMRouter {
             connector.updateTokenPrice(poolId, trancheId, price);
         } else if (ConnectorMessages.isTransfer(_msg)) {
             (uint64 poolId, bytes16 trancheId,, address destinationAddress, uint128 amount) =
-                ConnectorMessages.parseTransfer(_msg);
+                ConnectorMessages.parseTransfer20(_msg);
             connector.handleTransfer(poolId, trancheId, destinationAddress, amount);
         } else {
             require(false, "invalid-message");

--- a/test/Connector.t.sol
+++ b/test/Connector.t.sol
@@ -268,7 +268,7 @@ contract ConnectorTest is Test {
 
         // Now send the transfer from EVM -> Cent Chain
         token.approve(address(bridgedConnector), amount);
-        bridgedConnector.transfer(poolId, trancheId, ConnectorMessages.Domain.Centrifuge, centChainAddress, amount);
+        bridgedConnector.transferToCentrifuge(poolId, trancheId, centChainAddress, amount);
         assertEq(token.balanceOf(address(this)), 0);
 
         // Finally, verify the connector called `router.send`
@@ -280,20 +280,6 @@ contract ConnectorTest is Test {
             amount
         );
         assertEq(mockXcmRouter.sentMessages(message), true);
-    }
-
-    // Test that an outbound transfer fails when targeting a domain that is not Centrifuge
-    function testTransferToInvalidDomain(uint64 poolId, bytes16 trancheId, bytes32 centChainAddress, uint128 amount)
-        public
-    {
-        vm.expectRevert(bytes("CentrifugeConnector/invalid-domain"));
-        bridgedConnector.transfer(poolId, trancheId, ConnectorMessages.Domain.EVM, centChainAddress, amount);
-
-        // Verify the connector did NOT call `router.send`
-        bytes memory message = ConnectorMessages.formatTransfer(
-            poolId, trancheId, ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM), centChainAddress, amount
-        );
-        assertFalse(mockXcmRouter.sentMessages(message));
     }
 
     function testTransferFromCentrifuge(

--- a/test/Connector.t.sol
+++ b/test/Connector.t.sol
@@ -243,7 +243,7 @@ contract ConnectorTest is Test {
         string memory tokenSymbol,
         bytes16 trancheId,
         uint128 price,
-        address centChainAddress,
+        bytes32 centChainAddress,
         uint128 amount,
         uint64 validUntil
     ) public {
@@ -283,7 +283,7 @@ contract ConnectorTest is Test {
     }
 
     // Test that an outbound transfer fails when targeting a domain that is not Centrifuge
-    function testTransferToInvalidDomain(uint64 poolId, bytes16 trancheId, address centChainAddress, uint128 amount)
+    function testTransferToInvalidDomain(uint64 poolId, bytes16 trancheId, bytes32 centChainAddress, uint128 amount)
         public
     {
         vm.expectRevert(bytes("CentrifugeConnector/invalid-domain"));
@@ -319,7 +319,7 @@ contract ConnectorTest is Test {
         assertEq(ERC20Like(token).balanceOf(destinationAddress), amount);
     }
 
-    function testTransferFromEVM(
+    function testTransferToEVM(
         uint64 poolId,
         string memory tokenName,
         string memory tokenSymbol,
@@ -343,7 +343,7 @@ contract ConnectorTest is Test {
         assertEq(ERC20Like(token).balanceOf(destinationAddress), amount);
     }
 
-    function testTransferFromEVMWithoutMemberFails(
+    function testTransferToEVMWithoutMemberFails(
         uint64 poolId,
         string memory tokenName,
         string memory tokenSymbol,

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -247,13 +247,13 @@ contract MessagesTest is Test {
     ) public {
         bytes9 inputEncodedDomain = ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge);
         bytes memory _message =
-        ConnectorMessages.formatTransfer(poolId, trancheId, inputEncodedDomain, destinationAddress, amount);
+            ConnectorMessages.formatTransfer(poolId, trancheId, inputEncodedDomain, destinationAddress, amount);
         (
-        uint64 decodedPoolId,
-        bytes16 decodedTrancheId,
-        bytes9 encodedDomain,
-        bytes32 decodedDestinationAddress,
-        uint256 decodedAmount
+            uint64 decodedPoolId,
+            bytes16 decodedTrancheId,
+            bytes9 encodedDomain,
+            bytes32 decodedDestinationAddress,
+            uint256 decodedAmount
         ) = ConnectorMessages.parseTransfer32(_message.ref(0));
         assertEq(uint256(decodedPoolId), uint256(poolId));
         assertEq(decodedTrancheId, trancheId);

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -176,7 +176,7 @@ contract MessagesTest is Test {
 
     function testTransferToEvmDomainDecoding() public {
         (uint64 poolId, bytes16 trancheId, bytes9 domain, address destinationAddress, uint128 amount) =
-        ConnectorMessages.parseTransfer(
+        ConnectorMessages.parseTransfer20(
             fromHex(
                 "050000000000000001811acd5b3f17c06841c7e41e9e04cb1b010000000000000504123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000"
             ).ref(0)
@@ -194,28 +194,28 @@ contract MessagesTest is Test {
                 1,
                 bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"),
                 ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge),
-                0x1231231231231231231231231231231231231231,
+                0x1231231231231231231231231231231231231231231231231231231231231231,
                 1000000000000000000000000000
             ),
-            hex"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b000000000000000000123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000"
+            hex"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b000000000000000000123123123123123123123123123123123123123123123123123123123123123100000000033b2e3c9fd0803ce8000000"
         );
     }
 
     function testTransferToCentrifugeDecoding() public {
-        (uint64 poolId, bytes16 trancheId, bytes9 domain, address destinationAddress, uint128 amount) =
-        ConnectorMessages.parseTransfer(
+        (uint64 poolId, bytes16 trancheId, bytes9 domain, bytes32 destinationAddress, uint128 amount) =
+        ConnectorMessages.parseTransfer32(
             fromHex(
-                "050000000000000001811acd5b3f17c06841c7e41e9e04cb1b000000000000000000123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000"
+                "050000000000000001811acd5b3f17c06841c7e41e9e04cb1b000000000000000000123123123123123123123123123123123123123123123123123123123123123100000000033b2e3c9fd0803ce8000000"
             ).ref(0)
         );
         assertEq(uint256(poolId), uint256(1));
         assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
         assertEq(domain, ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge));
-        assertEq(destinationAddress, 0x1231231231231231231231231231231231231231);
+        assertEq(destinationAddress, bytes32(hex"1231231231231231231231231231231231231231231231231231231231231231"));
         assertEq(amount, uint256(1000000000000000000000000000));
     }
 
-    function testTransferEquivalence(
+    function testTransferToEvmEquivalence(
         uint64 poolId,
         bytes16 trancheId,
         address destinationAddress,
@@ -231,7 +231,30 @@ contract MessagesTest is Test {
             bytes9 encodedDomain,
             address decodedDestinationAddress,
             uint256 decodedAmount
-        ) = ConnectorMessages.parseTransfer(_message.ref(0));
+        ) = ConnectorMessages.parseTransfer20(_message.ref(0));
+        assertEq(uint256(decodedPoolId), uint256(poolId));
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(encodedDomain, inputEncodedDomain);
+        assertEq(decodedDestinationAddress, destinationAddress);
+        assertEq(decodedAmount, amount);
+    }
+
+    function testTransferToCentrifugeEquivalence(
+        uint64 poolId,
+        bytes16 trancheId,
+        bytes32 destinationAddress,
+        uint128 amount
+    ) public {
+        bytes9 inputEncodedDomain = ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge);
+        bytes memory _message =
+        ConnectorMessages.formatTransfer(poolId, trancheId, inputEncodedDomain, destinationAddress, amount);
+        (
+        uint64 decodedPoolId,
+        bytes16 decodedTrancheId,
+        bytes9 encodedDomain,
+        bytes32 decodedDestinationAddress,
+        uint256 decodedAmount
+        ) = ConnectorMessages.parseTransfer32(_message.ref(0));
         assertEq(uint256(decodedPoolId), uint256(poolId));
         assertEq(decodedTrancheId, trancheId);
         assertEq(encodedDomain, inputEncodedDomain);

--- a/test/Misc.t.sol
+++ b/test/Misc.t.sol
@@ -14,7 +14,7 @@ contract MiscTest is Test {
 
     function testAddressToBytes32Cast() public {
         assertEq(
-            bytes32(abi.encodePacked(hex"1231231231231231231231231231231231231231")),
+            bytes32(bytes20(address(bytes20(hex"1231231231231231231231231231231231231231")))),
             bytes32(hex"1231231231231231231231231231231231231231000000000000000000000000")
         );
 
@@ -23,6 +23,13 @@ contract MiscTest is Test {
             bytes32(
                 abi.encodePacked(hex"1231231231231231231231231231231231231231", bytes(hex"000000000000000000000000"))
             )
+        );
+    }
+
+    function testBytes32ToAddress() public {
+        assertEq(
+            address(bytes20(bytes32(hex"1231231231231231231231231231231231231231000000000000000000000000"))),
+            address(bytes20(hex"1231231231231231231231231231231231231231"))
         );
     }
 }

--- a/test/Misc.t.sol
+++ b/test/Misc.t.sol
@@ -20,8 +20,9 @@ contract MiscTest is Test {
 
         assertEq(
             bytes32(abi.encodePacked(hex"1231231231231231231231231231231231231231")),
-            bytes32(abi.encodePacked(hex"1231231231231231231231231231231231231231", bytes(hex"000000000000000000000000")))
+            bytes32(
+                abi.encodePacked(hex"1231231231231231231231231231231231231231", bytes(hex"000000000000000000000000"))
+            )
         );
-
     }
 }

--- a/test/Misc.t.sol
+++ b/test/Misc.t.sol
@@ -11,4 +11,17 @@ contract MiscTest is Test {
     function testCallIndex() public {
         assertEq(abi.encodePacked(uint8(uint256(108)), uint8(uint256(99))), hex"6c63");
     }
+
+    function testAddressToBytes32Cast() public {
+        assertEq(
+            bytes32(abi.encodePacked(hex"1231231231231231231231231231231231231231")),
+            bytes32(hex"1231231231231231231231231231231231231231000000000000000000000000")
+        );
+
+        assertEq(
+            bytes32(abi.encodePacked(hex"1231231231231231231231231231231231231231")),
+            bytes32(abi.encodePacked(hex"1231231231231231231231231231231231231231", bytes(hex"000000000000000000000000")))
+        );
+
+    }
 }

--- a/test/mock/MockHomeConnector.sol
+++ b/test/mock/MockHomeConnector.sol
@@ -59,7 +59,7 @@ contract MockHomeConnector is Test {
         router.handle(_message);
     }
 
-    // Triggger an incoming (e.g. Centrifuge Chain -> EVM) transfer
+    // Trigger an incoming (e.g. Centrifuge Chain -> EVM) transfer
     function transfer(
         uint64 poolId,
         bytes16 trancheId,

--- a/test/mock/MockXcmRouter.sol
+++ b/test/mock/MockXcmRouter.sol
@@ -42,7 +42,7 @@ contract MockXcmRouter is Test {
             connector.updateTokenPrice(poolId, trancheId, price);
         } else if (ConnectorMessages.isTransfer(_msg)) {
             (uint64 poolId, bytes16 trancheId,, address destinationAddress, uint128 amount) =
-                ConnectorMessages.parseTransfer(_msg);
+                ConnectorMessages.parseTransfer20(_msg);
             connector.handleTransfer(poolId, trancheId, destinationAddress, amount);
         } else {
             require(false, "invalid-message");


### PR DESCRIPTION
Currently, when calling `Connector.transfer` we can only pass a 20-byte long address as the destination address, to which we then append 12 zeros to make it a 32-byte long array as expected by the Transfer message format.

Here, we allow for a 32-byte address to be passed for the outgoing transfer API.