### PR TITLE
messages: Clean up and align with Centrifuge chain

### DIFF
--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -177,18 +177,21 @@ library ConnectorMessages {
      * 25-45: user (Ethereum address, 20 bytes - Skip 12 bytes from 32-byte addresses)
      * 57-65: validUntil (uint64 = 8 bytes)
      *
-     * TODO: use bytes32 for user (for non-EVM compatibility)
      */
-    function formatUpdateMember(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil)
+    function formatUpdateMember(uint64 poolId, bytes16 trancheId, address member, uint64 validUntil)
         internal
         pure
         returns (bytes memory)
     {
-        // NOTE: Since parseUpdateMember parses the first 20 bytes of `user` and skips the following 12
-        // here we need to append 12 zeros to make it right. Drop once we support 32-byte addresses.
-        return abi.encodePacked(
-            uint8(Call.UpdateMember), poolId, trancheId, user, bytes(hex"000000000000000000000000"), validUntil
-        );
+        return formatUpdateMember(poolId, trancheId, bytes32(bytes20(member)), validUntil);
+    }
+
+    function formatUpdateMember(uint64 poolId, bytes16 trancheId, bytes32 member, uint64 validUntil)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(uint8(Call.UpdateMember), poolId, trancheId, member, validUntil);
     }
 
     function isUpdateMember(bytes29 _msg) internal pure returns (bool) {

--- a/test/Messages.t.sol
+++ b/test/Messages.t.sol
@@ -13,19 +13,17 @@ contract MessagesTest is Test {
 
     function setUp() public {}
 
-    function testAddCurrencyEncoding() public {
-        assertEq(
-            ConnectorMessages.formatAddCurrency(42, 0x1234567890123456789012345678901234567890),
-            fromHex("010000000000000000000000000000002a1234567890123456789012345678901234567890")
-        );
-    }
+    function testAddCurrency() public {
+        uint128 currency = 246803579;
+        address currencyAddress = 0x1231231231231231231231231231231231231231;
+        bytes memory expectedHex = hex"010000000000000000000000000eb5ec7b1231231231231231231231231231231231231231";
 
-    function testAddCurrencyDecoding() public {
-        (uint128 currency, address currencyAddress) = ConnectorMessages.parseAddCurrency(
-            fromHex("010000000000000000000000000000002a1234567890123456789012345678901234567890").ref(0)
-        );
-        assertEq(uint256(currency), 42);
-        assertEq(currencyAddress, 0x1234567890123456789012345678901234567890);
+        assertEq(ConnectorMessages.formatAddCurrency(currency, currencyAddress), expectedHex);
+
+        (uint128 decodedCurrency, address decodedCurrencyAddress) =
+            ConnectorMessages.parseAddCurrency(expectedHex.ref(0));
+        assertEq(uint256(decodedCurrency), currency);
+        assertEq(decodedCurrencyAddress, currencyAddress);
     }
 
     function testAddCurrencyEquivalence(uint128 currency, address currencyAddress) public {
@@ -35,21 +33,14 @@ contract MessagesTest is Test {
         assertEq(decodedCurrencyAddress, currencyAddress);
     }
 
-    function testAddPoolEncoding() public {
-        assertEq(ConnectorMessages.formatAddPool(0), fromHex("020000000000000000"));
-        assertEq(ConnectorMessages.formatAddPool(1), fromHex("020000000000000001"));
-        assertEq(ConnectorMessages.formatAddPool(12378532), fromHex("020000000000bce1a4"));
-    }
+    function testAddPool() public {
+        uint64 poolId = 12378532;
+        bytes memory expectedHex = hex"020000000000bce1a4";
 
-    function testAddPoolDecoding() public {
-        (uint64 actualPoolId1) = ConnectorMessages.parseAddPool(fromHex("020000000000000000").ref(0));
-        assertEq(uint256(actualPoolId1), 0);
+        assertEq(ConnectorMessages.formatAddPool(poolId), expectedHex);
 
-        (uint64 actualPoolId2) = ConnectorMessages.parseAddPool(fromHex("020000000000000001").ref(0));
-        assertEq(uint256(actualPoolId2), 1);
-
-        (uint64 actualPoolId3) = ConnectorMessages.parseAddPool(fromHex("020000000000bce1a4").ref(0));
-        assertEq(uint256(actualPoolId3), 12378532);
+        (uint64 decodedPoolId) = ConnectorMessages.parseAddPool(expectedHex.ref(0));
+        assertEq(uint256(decodedPoolId), poolId);
     }
 
     function testAddPoolEquivalence(uint64 poolId) public {
@@ -58,18 +49,16 @@ contract MessagesTest is Test {
         assertEq(decodedPoolId, uint256(poolId));
     }
 
-    function testAllowPoolCurrencyEncoding() public {
-        assertEq(
-            ConnectorMessages.formatAllowPoolCurrency(99, 42), hex"0300000000000000630000000000000000000000000000002a"
-        );
-    }
+    function testAllowPoolCurrency() public {
+        uint64 poolId = 12378532;
+        uint128 currency = 246803579;
+        bytes memory expectedHex = hex"030000000000bce1a40000000000000000000000000eb5ec7b";
 
-    function testAllowPoolCurrencyDecoding() public {
-        (uint64 actualPoolId, uint128 actualCurrency) = ConnectorMessages.parseAllowPoolCurrency(
-            fromHex("0300000000000000630000000000000000000000000000002a").ref(0)
-        );
-        assertEq(actualPoolId, 99);
-        assertEq(uint256(actualCurrency), 42);
+        assertEq(ConnectorMessages.formatAllowPoolCurrency(poolId, currency), expectedHex);
+
+        (uint64 decodedPoolId, uint128 decodedCurrency) = ConnectorMessages.parseAllowPoolCurrency(expectedHex.ref(0));
+        assertEq(decodedPoolId, poolId);
+        assertEq(uint256(decodedCurrency), currency);
     }
 
     function testAllowPoolCurrencyEquivalence(uint128 currency, uint64 poolId) public {
@@ -79,21 +68,18 @@ contract MessagesTest is Test {
         assertEq(decodedCurrency, uint256(currency));
     }
 
-    function testAddTrancheEncoding() public {
-        assertEq(
-            ConnectorMessages.formatAddTranche(
-                12378532,
-                bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"),
-                "Some Name",
-                "SYMBOL",
-                18,
-                1000000000000000000000000000
-            ),
-            hex"040000000000bce1a4811acd5b3f17c06841c7e41e9e04cb1b536f6d65204e616d65000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000053594d424f4c00000000000000000000000000000000000000000000000000001200000000033b2e3c9fd0803ce8000000"
-        );
-    }
+    function testAddTranche() public {
+        uint64 poolId = 1;
+        bytes16 trancheId = bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        string memory name = "Some Name";
+        string memory symbol = "SYMBOL";
+        uint8 decimals = 15;
+        uint128 price = 1_000_000_000_000_000_000_000_000_000;
+        bytes memory expectedHex =
+            hex"040000000000000001811acd5b3f17c06841c7e41e9e04cb1b536f6d65204e616d65000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000053594d424f4c00000000000000000000000000000000000000000000000000000f00000000033b2e3c9fd0803ce8000000";
 
-    function testAddTrancheDecoding() public {
+        assertEq(ConnectorMessages.formatAddTranche(poolId, trancheId, name, symbol, decimals, price), expectedHex);
+
         (
             uint64 decodedPoolId,
             bytes16 decodedTrancheId,
@@ -101,17 +87,14 @@ contract MessagesTest is Test {
             string memory decodedTokenSymbol,
             uint8 decodedDecimals,
             uint128 decodedPrice
-        ) = ConnectorMessages.parseAddTranche(
-            fromHex(
-                "040000000000bce1a4811acd5b3f17c06841c7e41e9e04cb1b536f6d65204e616d65000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000053594d424f4c00000000000000000000000000000000000000000000000000001200000000033b2e3c9fd0803ce8000000"
-            ).ref(0)
-        );
-        assertEq(uint256(decodedPoolId), uint256(12378532));
-        assertEq(decodedTrancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
-        assertEq(decodedTokenName, bytes32ToString(bytes32("Some Name")));
-        assertEq(decodedTokenSymbol, bytes32ToString(bytes32("SYMBOL")));
-        assertEq(decodedDecimals, 18);
-        assertEq(decodedPrice, uint256(1000000000000000000000000000));
+        ) = ConnectorMessages.parseAddTranche(expectedHex.ref(0));
+
+        assertEq(uint256(decodedPoolId), poolId);
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedTokenName, name);
+        assertEq(decodedTokenSymbol, symbol);
+        assertEq(decodedDecimals, decimals);
+        assertEq(decodedPrice, price);
     }
 
     function testAddTrancheEquivalence(
@@ -144,34 +127,50 @@ contract MessagesTest is Test {
         assertEq(uint256(decodedPrice), uint256(price));
     }
 
+    function testUpdateTrancheTokenPrice() public {
+        uint64 poolId = 1;
+        bytes16 trancheId = bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        uint128 price = 1_000_000_000_000_000_000_000_000_000;
+        bytes memory expectedHex =
+            hex"050000000000000001811acd5b3f17c06841c7e41e9e04cb1b00000000033b2e3c9fd0803ce8000000";
+
+        assertEq(ConnectorMessages.formatUpdateTrancheTokenPrice(poolId, trancheId, price), expectedHex);
+
+        (uint64 decodedPoolId, bytes16 decodedTrancheId, uint128 decodedPrice) =
+            ConnectorMessages.parseUpdateTrancheTokenPrice(expectedHex.ref(0));
+        assertEq(uint256(decodedPoolId), poolId);
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedPrice, price);
+    }
+
+    function testUpdateTrancheTokenPriceEquivalence(uint64 poolId, bytes16 trancheId, uint128 price) public {
+        bytes memory _message = ConnectorMessages.formatUpdateTrancheTokenPrice(poolId, trancheId, price);
+        (uint64 decodedPoolId, bytes16 decodedTrancheId, uint128 decodedPrice) =
+            ConnectorMessages.parseUpdateTrancheTokenPrice(_message.ref(0));
+        assertEq(uint256(decodedPoolId), uint256(poolId));
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(uint256(decodedPrice), uint256(price));
+    }
+
     // Note: UpdateMember encodes differently in Solidity compared to the Rust counterpart because `user` is a 20-byte
     // value in Solidity while it is 32-byte in Rust. However, UpdateMember messages coming from the cent-chain will
     // be handled correctly as the last 12 bytes out of said 32 will be ignored.
-    function testUpdateMemberEncoding() public {
-        assertEq(
-            ConnectorMessages.formatUpdateMember(
-                2,
-                bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"),
-                0x1231231231231231231231231231231231231231,
-                1706260138
-            ),
-            hex"060000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312310000000000000000000000000000000065b376aa"
-        );
-    }
+    function testUpdateMember() public {
+        uint64 poolId = 2;
+        bytes16 trancheId = bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        bytes32 member = bytes32(0x4564564564564564564564564564564564564564564564564564564564564564);
+        uint64 validUntil = 1706260138;
+        bytes memory expectedHex =
+            hex"060000000000000002811acd5b3f17c06841c7e41e9e04cb1b45645645645645645645645645645645645645645645645645645645645645640000000065b376aa";
 
-    // We use an UpdateMember encoded message generated in the cent-chain to
-    // verify we handle the 32 to 20 bytes address compatibility as expected.
-    function testUpdateMemberDecoding() public {
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedUser, uint64 decodedValidUntil) =
-        ConnectorMessages.parseUpdateMember(
-            fromHex(
-                "040000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000065b376aa"
-            ).ref(0)
-        );
-        assertEq(uint256(decodedPoolId), uint256(2));
-        assertEq(decodedTrancheId, hex"811acd5b3f17c06841c7e41e9e04cb1b");
-        assertEq(decodedUser, 0x1231231231231231231231231231231231231231);
-        assertEq(decodedValidUntil, uint256(1706260138));
+        assertEq(ConnectorMessages.formatUpdateMember(poolId, trancheId, member, validUntil), expectedHex);
+
+        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedMember, uint64 decodedValidUntil) =
+            ConnectorMessages.parseUpdateMember(expectedHex.ref(0));
+        assertEq(uint256(decodedPoolId), poolId);
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedMember, address(bytes20(member)));
+        assertEq(decodedValidUntil, validUntil);
     }
 
     function testUpdateMemberEquivalence(uint64 poolId, bytes16 trancheId, address user, uint64 validUntil) public {
@@ -184,62 +183,29 @@ contract MessagesTest is Test {
         assertEq(uint256(decodedValidUntil), uint256(validUntil));
     }
 
-    function testUpdateTrancheTokenPriceEncoding() public {
-        assertEq(
-            ConnectorMessages.formatUpdateTrancheTokenPrice(
-                1, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"), 1000000000000000000000000000
-            ),
-            fromHex("050000000000000001811acd5b3f17c06841c7e41e9e04cb1b00000000033b2e3c9fd0803ce8000000")
-        );
-    }
+    function testTransfer() public {
+        uint64 currency = 246803579;
+        bytes32 sender = bytes32(0x4564564564564564564564564564564564564564564564564564564564564564);
+        address receiver = 0x1231231231231231231231231231231231231231;
+        uint128 amount = 100000000000000000000000000;
+        bytes memory expectedHex =
+            hex"070000000000000000000000000eb5ec7b45645645645645645645645645645645645645645645645645645645645645641231231231231231231231231231231231231231000000000000000000000000000000000052b7d2dcc80cd2e4000000";
 
-    function testUpdateTrancheTokenPriceDecoding() public {
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, uint128 decodedPrice) = ConnectorMessages
-            .parseUpdateTrancheTokenPrice(
-            fromHex("030000000000000001811acd5b3f17c06841c7e41e9e04cb1b00000000033b2e3c9fd0803ce8000000").ref(0)
-        );
-        assertEq(uint256(decodedPoolId), uint256(1));
-        assertEq(decodedTrancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
-        assertEq(decodedPrice, uint256(1000000000000000000000000000));
-    }
+        assertEq(ConnectorMessages.formatTransfer(currency, sender, bytes32(bytes20(receiver)), amount), expectedHex);
 
-    function testUpdateTrancheTokenPriceEquivalence(uint64 poolId, bytes16 trancheId, uint128 price) public {
-        bytes memory _message = ConnectorMessages.formatUpdateTrancheTokenPrice(poolId, trancheId, price);
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, uint128 decodedPrice) =
-            ConnectorMessages.parseUpdateTrancheTokenPrice(_message.ref(0));
-        assertEq(uint256(decodedPoolId), uint256(poolId));
-        assertEq(decodedTrancheId, trancheId);
-        assertEq(uint256(decodedPrice), uint256(price));
-    }
-
-    function testTransferEncoding() public {
-        assertEq(
-            ConnectorMessages.formatTransfer(
-                uint128(42),
-                0x1111111111111111111111111111111111111111111111111111111111111111,
-                0x2222222222222222222222222222222222222222222222222222222222222222,
-                1000000000000000000000000000
-            ),
-            hex"070000000000000000000000000000002a1111111111111111111111111111111111111111111111111111111111111111222222222222222222222222222222222222222222222222222222222222222200000000033b2e3c9fd0803ce8000000"
-        );
-    }
-
-    function testTransferDecoding() public {
-        bytes29 message = fromHex(
-            "070000000000000000000000000000002a1111111111111111111111111111111111111111111111111111111111111111222222222222222222222222222222222222222222222222222222222222222200000000033b2e3c9fd0803ce8000000"
-        ).ref(0);
-
-        (uint128 token, bytes32 sender, bytes32 recipient, uint128 amount) = ConnectorMessages.parseTransfer(message);
-        assertEq(uint256(token), uint256(42));
-        assertEq(sender, 0x1111111111111111111111111111111111111111111111111111111111111111);
-        assertEq(recipient, 0x2222222222222222222222222222222222222222222222222222222222222222);
-        assertEq(amount, uint256(1000000000000000000000000000));
+        (uint128 decodedCurrency, bytes32 decodedSender, bytes32 decodedReceiver, uint128 decodedAmount) =
+            ConnectorMessages.parseTransfer(expectedHex.ref(0));
+        assertEq(uint256(decodedCurrency), currency);
+        assertEq(decodedSender, sender);
+        assertEq(decodedReceiver, bytes32(bytes20(receiver)));
+        assertEq(decodedAmount, amount);
 
         // Test the optimised `parseIncomingTransfer` now
-        (uint128 token2, address recipient2, uint128 amount2) = ConnectorMessages.parseIncomingTransfer(message);
-        assertEq(uint256(token2), uint256(token));
-        assertEq(recipient2, address(bytes20(recipient)));
-        assertEq(amount, amount2);
+        (uint128 decodedCurrency2, address decodedReceiver2, uint128 decodedAmount2) =
+            ConnectorMessages.parseIncomingTransfer(expectedHex.ref(0));
+        assertEq(uint256(decodedCurrency2), currency);
+        assertEq(decodedReceiver2, receiver);
+        assertEq(decodedAmount, amount);
     }
 
     function testTransferEquivalence(uint128 token, bytes32 sender, bytes32 receiver, uint128 amount) public {
@@ -259,60 +225,60 @@ contract MessagesTest is Test {
         assertEq(decodedAmount, decodedAmount2);
     }
 
-    function testTransferTrancheTokensToEvmDomainEncoding() public {
+    function testTransferTrancheTokensToEvm() public {
+        uint64 poolId = 1;
+        bytes16 trancheId = bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        bytes32 sender = bytes32(0x4564564564564564564564564564564564564564564564564564564564564564);
+        bytes9 domain = ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, 1284);
+        address receiver = 0x1231231231231231231231231231231231231231;
+        uint128 amount = 100000000000000000000000000;
+        bytes memory expectedHex =
+            hex"080000000000000001811acd5b3f17c06841c7e41e9e04cb1b45645645645645645645645645645645645645645645645645645645645645640100000000000005041231231231231231231231231231231231231231000000000000000000000000000000000052b7d2dcc80cd2e4000000";
+
+        assertEq(
+            ConnectorMessages.formatTransferTrancheTokens(poolId, trancheId, sender, domain, receiver, amount),
+            expectedHex
+        );
+
+        (uint64 decodedPoolId, bytes16 decodedTrancheId, address decodedReceiver, uint128 decodedAmount) =
+            ConnectorMessages.parseTransferTrancheTokens20(expectedHex.ref(0));
+        assertEq(uint256(decodedPoolId), poolId);
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedReceiver, receiver);
+        assertEq(decodedAmount, amount);
+    }
+
+    function testTransferTrancheTokensToCentrifuge() public {
+        uint64 poolId = 1;
+        bytes16 trancheId = bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        address sender = 0x1231231231231231231231231231231231231231;
+        bytes9 domain = ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge);
+        bytes32 receiver = bytes32(0x4564564564564564564564564564564564564564564564564564564564564564);
+        uint128 amount = 100000000000000000000000000;
+        bytes memory expectedHex =
+            hex"080000000000000001811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312310000000000000000000000000000000000000000004564564564564564564564564564564564564564564564564564564564564564000000000052b7d2dcc80cd2e4000000";
+
         assertEq(
             ConnectorMessages.formatTransferTrancheTokens(
-                1,
-                bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"),
-                0x1231231231231231231231231231231231231231231231231231231231231231,
-                ConnectorMessages.formatDomain(ConnectorMessages.Domain.EVM, 1284),
-                0x1231231231231231231231231231231231231231,
-                1000000000000000000000000000
+                poolId, trancheId, bytes32(bytes20(sender)), domain, receiver, amount
             ),
-            hex"080000000000000001811acd5b3f17c06841c7e41e9e04cb1b1231231231231231231231231231231231231231231231231231231231231231010000000000000504123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000"
+            expectedHex
         );
-    }
 
-    function testTransferTrancheTokensToEvmDomainDecoding() public {
-        (uint64 poolId, bytes16 trancheId, address destinationAddress, uint128 amount) = ConnectorMessages
-            .parseTransferTrancheTokens20(
-            fromHex(
-                "080000000000000001811acd5b3f17c06841c7e41e9e04cb1b1231231231231231231231231231231231231231231231231231231231231231010000000000000504123123123123123123123123123123123123123100000000000000000000000000000000033b2e3c9fd0803ce8000000"
-            ).ref(0)
-        );
-        assertEq(uint256(poolId), uint256(1));
-        assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
-        assertEq(destinationAddress, 0x1231231231231231231231231231231231231231);
-        assertEq(amount, uint256(1000000000000000000000000000));
-    }
-
-    function testTransferTrancheTokensToCentrifugeEncoding() public {
-        assertEq(
-            ConnectorMessages.formatTransferTrancheTokens(
-                1,
-                bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"),
-                bytes32(bytes20(0x1231231231231231231231231231231231231231)),
-                ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge),
-                0x1231231231231231231231231231231231231231231231231231231231231231,
-                1000000000000000000000000000
-            ),
-            hex"080000000000000001811acd5b3f17c06841c7e41e9e04cb1b1231231231231231231231231231231231231231000000000000000000000000000000000000000000123123123123123123123123123123123123123123123123123123123123123100000000033b2e3c9fd0803ce8000000"
-        );
-    }
-
-    function testTransferTrancheTokensToCentrifugeDecoding() public {
-        (uint64 poolId, bytes16 trancheId, bytes32 sender, bytes9 domain, bytes32 destinationAddress, uint128 amount) =
-        ConnectorMessages.parseTransferTrancheTokens32(
-            fromHex(
-                "080000000000000001811acd5b3f17c06841c7e41e9e04cb1b1231231231231231231231231231231231231231000000000000000000000000000000000000000000123123123123123123123123123123123123123123123123123123123123123100000000033b2e3c9fd0803ce8000000"
-            ).ref(0)
-        );
-        assertEq(uint256(poolId), uint256(1));
-        assertEq(trancheId, bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"));
-        assertEq(sender, 0x1231231231231231231231231231231231231231000000000000000000000000);
-        assertEq(domain, ConnectorMessages.formatDomain(ConnectorMessages.Domain.Centrifuge));
-        assertEq(destinationAddress, bytes32(hex"1231231231231231231231231231231231231231231231231231231231231231"));
-        assertEq(amount, uint256(1000000000000000000000000000));
+        (
+            uint64 decodedPoolId,
+            bytes16 decodedTrancheId,
+            bytes32 decodedSender,
+            bytes9 decodedDomain,
+            bytes32 decodedReceiver,
+            uint128 decodedAmount
+        ) = ConnectorMessages.parseTransferTrancheTokens32(expectedHex.ref(0));
+        assertEq(uint256(decodedPoolId), poolId);
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedSender, bytes32(bytes20(sender)));
+        assertEq(decodedDomain, domain);
+        assertEq(decodedReceiver, receiver);
+        assertEq(decodedAmount, amount);
     }
 
     function testTransferTrancheTokensToEvmEquivalence(
@@ -367,32 +333,31 @@ contract MessagesTest is Test {
         assertEq(decodedAmount, amount);
     }
 
-    // IncreaseInvestOrder
-    function testIncreaseInvestOrderEncoding() public {
-        assertEq(
-            ConnectorMessages.formatIncreaseInvestOrder(
-                2,
-                bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"),
-                0x1231231231231231231231231231231231231231231231231231231231231231,
-                uint128(42),
-                1706260138
-            ),
-            hex"090000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000000000000000000000000002a00000000000000000000000065b376aa"
-        );
-    }
+    function testIncreaseInvestOrder() public {
+        uint64 poolId = 1;
+        bytes16 trancheId = bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        bytes32 investor = bytes32(0x4564564564564564564564564564564564564564564564564564564564564564);
+        uint128 currency = 246803579;
+        uint128 amount = 100000000000000000000000000;
+        bytes memory expectedHex =
+            hex"090000000000000001811acd5b3f17c06841c7e41e9e04cb1b45645645645645645645645645645645645645645645645645645645645645640000000000000000000000000eb5ec7b000000000052b7d2dcc80cd2e4000000";
 
-    function testIncreaseInvestOrderDecoding() public {
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, bytes32 decodedInvestor, uint128 token, uint128 amount) =
-        ConnectorMessages.parseIncreaseInvestOrder(
-            fromHex(
-                "090000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000000000000000000000000002a00000000000000000000000065b376aa"
-            ).ref(0)
+        assertEq(
+            ConnectorMessages.formatIncreaseInvestOrder(poolId, trancheId, investor, currency, amount), expectedHex
         );
-        assertEq(uint256(decodedPoolId), uint256(2));
-        assertEq(decodedTrancheId, hex"811acd5b3f17c06841c7e41e9e04cb1b");
-        assertEq(decodedInvestor, 0x1231231231231231231231231231231231231231231231231231231231231231);
-        assertEq(token, uint128(42));
-        assertEq(amount, uint128(1706260138));
+
+        (
+            uint64 decodedPoolId,
+            bytes16 decodedTrancheId,
+            bytes32 decodedInvestor,
+            uint128 decodedCurrency,
+            uint128 decodedAmount
+        ) = ConnectorMessages.parseIncreaseInvestOrder(expectedHex.ref(0));
+        assertEq(uint256(decodedPoolId), poolId);
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedInvestor, investor);
+        assertEq(decodedCurrency, currency);
+        assertEq(decodedAmount, amount);
     }
 
     function testIncreaseInvestOrderEquivalence(
@@ -418,32 +383,31 @@ contract MessagesTest is Test {
         assertEq(decodedAmount, amount);
     }
 
-    // DecreaseInvestOrder
-    function testDecreaseInvestOrderEncoding() public {
-        assertEq(
-            ConnectorMessages.formatDecreaseInvestOrder(
-                2,
-                bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"),
-                0x1231231231231231231231231231231231231231231231231231231231231231,
-                uint128(42),
-                1706260138
-            ),
-            hex"0a0000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000000000000000000000000002a00000000000000000000000065b376aa"
-        );
-    }
+    function testDecreaseInvestOrder() public {
+        uint64 poolId = 1;
+        bytes16 trancheId = bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        bytes32 investor = bytes32(0x4564564564564564564564564564564564564564564564564564564564564564);
+        uint128 currency = 246803579;
+        uint128 amount = 100000000000000000000000000;
+        bytes memory expectedHex =
+            hex"0a0000000000000001811acd5b3f17c06841c7e41e9e04cb1b45645645645645645645645645645645645645645645645645645645645645640000000000000000000000000eb5ec7b000000000052b7d2dcc80cd2e4000000";
 
-    function testDecreaseInvestOrderDecoding() public {
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, bytes32 decodedInvestor, uint128 token, uint128 amount) =
-        ConnectorMessages.parseDecreaseInvestOrder(
-            fromHex(
-                "0a0000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000000000000000000000000002a00000000000000000000000065b376aa"
-            ).ref(0)
+        assertEq(
+            ConnectorMessages.formatDecreaseInvestOrder(poolId, trancheId, investor, currency, amount), expectedHex
         );
-        assertEq(uint256(decodedPoolId), uint256(2));
-        assertEq(decodedTrancheId, hex"811acd5b3f17c06841c7e41e9e04cb1b");
-        assertEq(decodedInvestor, 0x1231231231231231231231231231231231231231231231231231231231231231);
-        assertEq(token, uint128(42));
-        assertEq(amount, uint128(1706260138));
+
+        (
+            uint64 decodedPoolId,
+            bytes16 decodedTrancheId,
+            bytes32 decodedInvestor,
+            uint128 decodedCurrency,
+            uint128 decodedAmount
+        ) = ConnectorMessages.parseDecreaseInvestOrder(expectedHex.ref(0));
+        assertEq(uint256(decodedPoolId), poolId);
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedInvestor, investor);
+        assertEq(decodedCurrency, currency);
+        assertEq(decodedAmount, amount);
     }
 
     function testDecreaseInvestOrderEquivalence(
@@ -469,32 +433,31 @@ contract MessagesTest is Test {
         assertEq(decodedAmount, amount);
     }
 
-    // IncreaseRedeemOrder
-    function testIncreaseRedeemOrderEncoding() public {
-        assertEq(
-            ConnectorMessages.formatIncreaseRedeemOrder(
-                2,
-                bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"),
-                0x1231231231231231231231231231231231231231231231231231231231231231,
-                uint128(42),
-                1706260138
-            ),
-            hex"0b0000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000000000000000000000000002a00000000000000000000000065b376aa"
-        );
-    }
+    function testIncreaseRedeemOrder() public {
+        uint64 poolId = 1;
+        bytes16 trancheId = bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        bytes32 investor = bytes32(0x4564564564564564564564564564564564564564564564564564564564564564);
+        uint128 currency = 246803579;
+        uint128 amount = 100000000000000000000000000;
+        bytes memory expectedHex =
+            hex"0b0000000000000001811acd5b3f17c06841c7e41e9e04cb1b45645645645645645645645645645645645645645645645645645645645645640000000000000000000000000eb5ec7b000000000052b7d2dcc80cd2e4000000";
 
-    function testIncreaseRedeemOrderDecoding() public {
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, bytes32 decodedInvestor, uint128 token, uint128 amount) =
-        ConnectorMessages.parseIncreaseRedeemOrder(
-            fromHex(
-                "0b0000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000000000000000000000000002a00000000000000000000000065b376aa"
-            ).ref(0)
+        assertEq(
+            ConnectorMessages.formatIncreaseRedeemOrder(poolId, trancheId, investor, currency, amount), expectedHex
         );
-        assertEq(uint256(decodedPoolId), uint256(2));
-        assertEq(decodedTrancheId, hex"811acd5b3f17c06841c7e41e9e04cb1b");
-        assertEq(decodedInvestor, 0x1231231231231231231231231231231231231231231231231231231231231231);
-        assertEq(token, uint128(42));
-        assertEq(amount, uint128(1706260138));
+
+        (
+            uint64 decodedPoolId,
+            bytes16 decodedTrancheId,
+            bytes32 decodedInvestor,
+            uint128 decodedCurrency,
+            uint128 decodedAmount
+        ) = ConnectorMessages.parseIncreaseRedeemOrder(expectedHex.ref(0));
+        assertEq(uint256(decodedPoolId), poolId);
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedInvestor, investor);
+        assertEq(decodedCurrency, currency);
+        assertEq(decodedAmount, amount);
     }
 
     function testIncreaseRedeemOrderEquivalence(
@@ -520,32 +483,31 @@ contract MessagesTest is Test {
         assertEq(decodedAmount, amount);
     }
 
-    // DecreaseRedeemOrder
-    function testDecreaseRedeemOrderEncoding() public {
-        assertEq(
-            ConnectorMessages.formatDecreaseRedeemOrder(
-                2,
-                bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"),
-                0x1231231231231231231231231231231231231231231231231231231231231231,
-                uint128(42),
-                1706260138
-            ),
-            hex"0c0000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000000000000000000000000002a00000000000000000000000065b376aa"
-        );
-    }
+    function testDecreaseRedeemOrder() public {
+        uint64 poolId = 1;
+        bytes16 trancheId = bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        bytes32 investor = bytes32(0x4564564564564564564564564564564564564564564564564564564564564564);
+        uint128 currency = 246803579;
+        uint128 amount = 100000000000000000000000000;
+        bytes memory expectedHex =
+            hex"0c0000000000000001811acd5b3f17c06841c7e41e9e04cb1b45645645645645645645645645645645645645645645645645645645645645640000000000000000000000000eb5ec7b000000000052b7d2dcc80cd2e4000000";
 
-    function testDecreaseRedeemOrderDecoding() public {
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, bytes32 decodedInvestor, uint128 token, uint128 amount) =
-        ConnectorMessages.parseDecreaseRedeemOrder(
-            fromHex(
-                "0c0000000000000002811acd5b3f17c06841c7e41e9e04cb1b12312312312312312312312312312312312312312312312312312312312312310000000000000000000000000000002a00000000000000000000000065b376aa"
-            ).ref(0)
+        assertEq(
+            ConnectorMessages.formatDecreaseRedeemOrder(poolId, trancheId, investor, currency, amount), expectedHex
         );
-        assertEq(uint256(decodedPoolId), uint256(2));
-        assertEq(decodedTrancheId, hex"811acd5b3f17c06841c7e41e9e04cb1b");
-        assertEq(decodedInvestor, 0x1231231231231231231231231231231231231231231231231231231231231231);
-        assertEq(token, uint128(42));
-        assertEq(amount, uint128(1706260138));
+
+        (
+            uint64 decodedPoolId,
+            bytes16 decodedTrancheId,
+            bytes32 decodedInvestor,
+            uint128 decodedCurrency,
+            uint128 decodedAmount
+        ) = ConnectorMessages.parseDecreaseRedeemOrder(expectedHex.ref(0));
+        assertEq(uint256(decodedPoolId), poolId);
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedInvestor, investor);
+        assertEq(decodedCurrency, currency);
+        assertEq(decodedAmount, amount);
     }
 
     function testDecreaseRedeemOrderEquivalence(
@@ -571,27 +533,20 @@ contract MessagesTest is Test {
         assertEq(decodedAmount, amount);
     }
 
-    // CollectInvest
-    function testCollectInvestEncoding() public {
-        assertEq(
-            ConnectorMessages.formatCollectInvest(
-                2,
-                bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"),
-                0x1231231231231231231231231231231231231231231231231231231231231231
-            ),
-            hex"0d0000000000000002811acd5b3f17c06841c7e41e9e04cb1b1231231231231231231231231231231231231231231231231231231231231231"
-        );
-    }
+    function testCollectInvest() public {
+        uint64 poolId = 1;
+        bytes16 trancheId = bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        bytes32 investor = bytes32(0x4564564564564564564564564564564564564564564564564564564564564564);
+        bytes memory expectedHex =
+            hex"0d0000000000000001811acd5b3f17c06841c7e41e9e04cb1b4564564564564564564564564564564564564564564564564564564564564564";
 
-    function testCollectInvestDecoding() public {
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, bytes32 decodedUser) = ConnectorMessages.parseCollectInvest(
-            fromHex(
-                "0d0000000000000002811acd5b3f17c06841c7e41e9e04cb1b1231231231231231231231231231231231231231231231231231231231231231"
-            ).ref(0)
-        );
-        assertEq(uint256(decodedPoolId), uint256(2));
-        assertEq(decodedTrancheId, hex"811acd5b3f17c06841c7e41e9e04cb1b");
-        assertEq(decodedUser, 0x1231231231231231231231231231231231231231231231231231231231231231);
+        assertEq(ConnectorMessages.formatCollectInvest(poolId, trancheId, investor), expectedHex);
+
+        (uint64 decodedPoolId, bytes16 decodedTrancheId, bytes32 decodedInvestor) =
+            ConnectorMessages.parseCollectInvest(expectedHex.ref(0));
+        assertEq(uint256(decodedPoolId), poolId);
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedInvestor, investor);
     }
 
     function testCollectInvestEquivalence(uint64 poolId, bytes16 trancheId, bytes32 user) public {
@@ -604,27 +559,20 @@ contract MessagesTest is Test {
         assertEq(decodedUser, user);
     }
 
-    // CollectRedeem
-    function testCollectRedeemEncoding() public {
-        assertEq(
-            ConnectorMessages.formatCollectRedeem(
-                2,
-                bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b"),
-                0x1231231231231231231231231231231231231231231231231231231231231231
-            ),
-            hex"0e0000000000000002811acd5b3f17c06841c7e41e9e04cb1b1231231231231231231231231231231231231231231231231231231231231231"
-        );
-    }
+    function testCollectRedeem() public {
+        uint64 poolId = 12378532;
+        bytes16 trancheId = bytes16(hex"811acd5b3f17c06841c7e41e9e04cb1b");
+        bytes32 investor = bytes32(0x4564564564564564564564564564564564564564564564564564564564564564);
+        bytes memory expectedHex =
+            hex"0e0000000000bce1a4811acd5b3f17c06841c7e41e9e04cb1b4564564564564564564564564564564564564564564564564564564564564564";
 
-    function testCollectRedeemDecoding() public {
-        (uint64 decodedPoolId, bytes16 decodedTrancheId, bytes32 decodedUser) = ConnectorMessages.parseCollectRedeem(
-            fromHex(
-                "0e0000000000000002811acd5b3f17c06841c7e41e9e04cb1b1231231231231231231231231231231231231231231231231231231231231231"
-            ).ref(0)
-        );
-        assertEq(uint256(decodedPoolId), uint256(2));
-        assertEq(decodedTrancheId, hex"811acd5b3f17c06841c7e41e9e04cb1b");
-        assertEq(decodedUser, 0x1231231231231231231231231231231231231231231231231231231231231231);
+        assertEq(ConnectorMessages.formatCollectRedeem(poolId, trancheId, investor), expectedHex);
+
+        (uint64 decodedPoolId, bytes16 decodedTrancheId, bytes32 decodedInvestor) =
+            ConnectorMessages.parseCollectRedeem(expectedHex.ref(0));
+        assertEq(uint256(decodedPoolId), poolId);
+        assertEq(decodedTrancheId, trancheId);
+        assertEq(decodedInvestor, investor);
     }
 
     function testCollectRedeemEquivalence(uint64 poolId, bytes16 trancheId, bytes32 user) public {


### PR DESCRIPTION
Closes 

We merge all the `test*Encoding` and `test*Decoding` tests in one `test*` unit where we essentially test the identity property of the format & parse functions for a given message. This reduces the number of test cases and the amount of duplicated data across them.

Here, we also align the tests with the Centrifuge Chain by using the values used over there and therefore verify that both systems, given the same message, encode them to the exact same hex and decode that same hex back to the original message.