### PR TITLE
XcmRouter: Update `message_length_scale_encoded`

### DIFF
--- a/src/routers/xcm/Router.sol
+++ b/src/routers/xcm/Router.sol
@@ -180,17 +180,17 @@ contract ConnectorXCMRouter {
             // A TransferTrancheTokens message is 82 bytes long which encodes to 0x4901 in Scale
             return hex"4901";
         } else if (ConnectorMessages.isIncreaseInvestOrder(_msg)) {
-            return hex"6c63";
+            return hex"6501";
         } else if (ConnectorMessages.isDecreaseInvestOrder(_msg)) {
-            return hex"6c63";
+            return hex"6501";
         } else if (ConnectorMessages.isIncreaseRedeemOrder(_msg)) {
-            return hex"6c63";
+            return hex"6501";
         } else if (ConnectorMessages.isDecreaseRedeemOrder(_msg)) {
-            return hex"6c63";
+            return hex"6501";
         } else if (ConnectorMessages.isCollectInvest(_msg)) {
-            return hex"6c63";
+            return hex"e4";
         } else if (ConnectorMessages.isCollectRedeem(_msg)) {
-            return hex"6c63";
+            return hex"e4";
         } else {
             revert("ConnectorXCMRouter/unsupported-outgoing-message");
         }

--- a/src/routers/xcm/Router.sol
+++ b/src/routers/xcm/Router.sol
@@ -176,30 +176,22 @@ contract ConnectorXCMRouter {
 
         if (ConnectorMessages.isTransfer(_msg)) {
             return hex"8501";
-        }
-        else if (ConnectorMessages.isTransferTrancheTokens(_msg)) {
+        } else if (ConnectorMessages.isTransferTrancheTokens(_msg)) {
             // A TransferTrancheTokens message is 82 bytes long which encodes to 0x4901 in Scale
             return hex"4901";
-        }
-        else if (ConnectorMessages.isIncreaseInvestOrder(_msg)) {
+        } else if (ConnectorMessages.isIncreaseInvestOrder(_msg)) {
             return hex"6c63";
-        }
-        else if (ConnectorMessages.isDecreaseInvestOrder(_msg)) {
+        } else if (ConnectorMessages.isDecreaseInvestOrder(_msg)) {
             return hex"6c63";
-        }
-        else if (ConnectorMessages.isIncreaseRedeemOrder(_msg)) {
+        } else if (ConnectorMessages.isIncreaseRedeemOrder(_msg)) {
             return hex"6c63";
-        }
-        else if (ConnectorMessages.isDecreaseRedeemOrder(_msg)) {
+        } else if (ConnectorMessages.isDecreaseRedeemOrder(_msg)) {
             return hex"6c63";
-        }
-        else if (ConnectorMessages.isCollectInvest(_msg)) {
+        } else if (ConnectorMessages.isCollectInvest(_msg)) {
             return hex"6c63";
-        }
-        else if (ConnectorMessages.isCollectRedeem(_msg)) {
+        } else if (ConnectorMessages.isCollectRedeem(_msg)) {
             return hex"6c63";
-        }
-        else {
+        } else {
             revert("ConnectorXCMRouter/unsupported-outgoing-message");
         }
     }

--- a/src/routers/xcm/Router.sol
+++ b/src/routers/xcm/Router.sol
@@ -174,10 +174,32 @@ contract ConnectorXCMRouter {
     function message_length_scale_encoded(bytes memory message) internal pure returns (bytes memory) {
         bytes29 _msg = message.ref(0);
 
-        if (ConnectorMessages.isTransferTrancheTokens(_msg)) {
+        if (ConnectorMessages.isTransfer(_msg)) {
+            return hex"8501";
+        }
+        else if (ConnectorMessages.isTransferTrancheTokens(_msg)) {
             // A TransferTrancheTokens message is 82 bytes long which encodes to 0x4901 in Scale
             return hex"4901";
-        } else {
+        }
+        else if (ConnectorMessages.isIncreaseInvestOrder(_msg)) {
+            return hex"6c63";
+        }
+        else if (ConnectorMessages.isDecreaseInvestOrder(_msg)) {
+            return hex"6c63";
+        }
+        else if (ConnectorMessages.isIncreaseRedeemOrder(_msg)) {
+            return hex"6c63";
+        }
+        else if (ConnectorMessages.isDecreaseRedeemOrder(_msg)) {
+            return hex"6c63";
+        }
+        else if (ConnectorMessages.isCollectInvest(_msg)) {
+            return hex"6c63";
+        }
+        else if (ConnectorMessages.isCollectRedeem(_msg)) {
+            return hex"6c63";
+        }
+        else {
             revert("ConnectorXCMRouter/unsupported-outgoing-message");
         }
     }


### PR DESCRIPTION
This is necessary to send v2 messages from the EVM down to the Centrifuge chain through the XCM Router.