### PR TITLE
rename `addAdmin` to `scheduleRely`

### DIFF
--- a/src/Messages.sol
+++ b/src/Messages.sol
@@ -8,8 +8,8 @@ library ConnectorMessages {
     using TypedMemView for bytes29;
 
     enum Call
-    /// 0 - An invalid message
     {
+        /// 0 - An invalid message
         Invalid,
         /// 1 - Add a currency id -> EVM address mapping
         AddCurrency,
@@ -47,8 +47,8 @@ library ConnectorMessages {
         ExecutedCollectInvest,
         /// 18 - Executed Collect Redeem
         ExecutedCollectRedeem,
-        /// 19 - Add a new admin
-        AddAdmin
+        /// 19 - Schedule an address to be given admin rights which can be executed after a delay
+        ScheduleRely
     }
 
     enum Domain {
@@ -746,15 +746,15 @@ library ConnectorMessages {
         remainingRedeemOrder = uint128(_msg.indexUint(105, 16));
     }
 
-    function formatAddAdmin(address user) internal pure returns (bytes memory) {
-        return abi.encodePacked(uint8(Call.AddAdmin), user);
+    function formatScheduleRely(address user) internal pure returns (bytes memory) {
+        return abi.encodePacked(uint8(Call.ScheduleRely), user);
     }
 
-    function isAddAdmin(bytes29 _msg) internal pure returns (bool) {
-        return messageType(_msg) == Call.AddAdmin;
+    function isScheduleRely(bytes29 _msg) internal pure returns (bool) {
+        return messageType(_msg) == Call.ScheduleRely;
     }
 
-    function parseAddAdmin(bytes29 _msg) internal pure returns (address user) {
+    function parseScheduleRely(bytes29 _msg) internal pure returns (address user) {
         user = address(bytes20(_msg.index(1, 20)));
     }
 

--- a/src/routers/Gateway.sol
+++ b/src/routers/Gateway.sol
@@ -359,8 +359,8 @@ contract ConnectorGateway {
             connector.handleExecutedCollectRedeem(
                 poolId, trancheId, investor, currency, currencyPayout, trancheTokensRedeemed, remainingRedeemOrder
             );
-        } else if (ConnectorMessages.isAddAdmin(_msg)) {
-            address spell = ConnectorMessages.parseAddAdmin(_msg);
+        } else if (ConnectorMessages.isScheduleRely(_msg)) {
+            address spell = ConnectorMessages.parseScheduleRely(_msg);
             scheduleShortRely(spell);
         } else {
             revert("ConnectorGateway/invalid-message");

--- a/test/mock/MockHomeConnector.sol
+++ b/test/mock/MockHomeConnector.sol
@@ -98,7 +98,7 @@ contract MockHomeConnector is Test {
     }
 
     function incomingScheduleRely(address spell) public {
-        bytes memory _message = ConnectorMessages.formatAddAdmin(spell);
+        bytes memory _message = ConnectorMessages.formatScheduleRely(spell);
         router.handle(_message);
     }
 


### PR DESCRIPTION
This PR renames the addAdmin event to scheduleRely to better fit with the general use case of the feature and the function names associated with the admin feature.